### PR TITLE
fix(SkyTable): size wrapper by max-content instead of summed widths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/shared/ui/SkyTable/Table.vue
+++ b/src/shared/ui/SkyTable/Table.vue
@@ -30,10 +30,16 @@
 
         <!-- Таблиця -->
         <div v-if="total" class="dynamic-scroller-table__table">
+          <!-- max-content замість суми оголошених ширин: браузер міряє реально
+               відрендерені колонки, тож шапка й тіло не розʼїжджаються, коли
+               клітинка ширша за свою оголошену частку. Явний minTableWidth
+               лишається як override. -->
           <div
             class="dynamic-scroller-table__table-wrapper"
             :style="{
-              'min-width': params.tableViewExpandedWidth + 'px' + '!important',
+              'min-width': params.minTableWidth
+                ? params.minTableWidth + 'px'
+                : 'max-content',
             }"
           >
             <header-table
@@ -212,27 +218,15 @@ const visibleToggleExpand = computed(() => {
 });
 
 // Watchers
+// Тримаємо header[].enable у синхроні з видимістю колонок. Ширину таблиці тут
+// більше не рахуємо: сума оголошених `width` / `widthFr * 100` була лише
+// оцінкою і розходилася з реальним рендером — тепер обгортка бере max-content.
 watch(
   selectedColumns,
   (_value) => {
-    if (props.params.minTableWidth) {
-      props.params.tableViewExpandedWidth = props.params.minTableWidth;
-    } else {
-      let width = 0;
-      props.params.header?.forEach((item) => {
-        item.enable = selectedColumns.value[item.name];
-        if (item.enable) {
-          if (item.width) {
-            width += item.width;
-          } else if (+item.widthFr) {
-            width += item.widthFr * 100;
-          } else {
-            width += 100;
-          }
-        }
-      });
-      props.params.tableViewExpandedWidth = width;
-    }
+    props.params.header?.forEach((item) => {
+      item.enable = selectedColumns.value[item.name];
+    });
   },
   { deep: true },
 );


### PR DESCRIPTION
## Проблема

`min-width` обгортки таблиці рахувався вручну — сумою оголошених ширин колонок:

```js
item.width ? width += item.width
: +item.widthFr ? width += item.widthFr * 100
: width += 100
```

Це оцінка, а не реальний рендер. Колонка з `widthFr` входила в бюджет як `widthFr * 100` незалежно від вмісту, тож клітинка ширша за свою частку розсовувала тіло таблиці, а шапка лишалась на старій ширині — остання колонка розʼїжджалася.

Знайшлось на таблиці товарів у skymarket: колонка тегів рахувалась як 300px (`widthFr: 3`), а реально потребувала більше.

## Рішення

Обгортка бере `min-width: max-content` — браузер міряє відрендерені колонки сам, тож шапка й тіло рахуються з одного джерела.

## Деталі

- **Вотчер не прибрано цілком.** Крім суми ширин він синхронізує `header[].enable` з видимістю колонок, а це читає ініціалізація в `onMounted`. Лишився тільки цей побічний ефект.
- **`minTableWidth` лишається як override** для таблиць, яким потрібна явна ширина.
- **`!important` прибрано** — у CSS `.dynamic-scroller-table__table-wrapper` немає жодного правила `min-width`, перебивати не було чого.
- **Версія піднята до 2.10.1.** Якщо релізи батчаться — цей рядок можна відкотити, фікс від нього не залежить.

## Перевірено

`npm run build` проходить, `tableViewExpandedWidth` більше не зустрічається ні в сорсах, ні в бандлі.