### PR TITLE
ci: publish to npm on push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - ".github/**"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      # У main прилітають і коміти без релізу — доки, рефакторинг, правки CI.
+      # Без цієї перевірки npm publish падав би з EPUBLISHCONFLICT на кожному
+      # такому пуші й фарбував історію Actions у червоне.
+      - name: Check whether this version is already published
+        id: check
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Пакет: $NAME@$VERSION"
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "Версія вже в реєстрі — публікацію пропускаємо."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Версії в реєстрі немає — публікуємо."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.check.outputs.should_publish == 'true'
+        run: npm ci
+
+      # Збірку робить сам npm через prepublishOnly.
+      # Авторизація — через .npmrc у репо, який читає NPM_TOKEN з оточення.
+      - name: Publish
+        if: steps.check.outputs.should_publish == 'true'
+        run: npm publish --access public
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Skipped
+        if: steps.check.outputs.should_publish != 'true'
+        run: echo "Версію не змінювали — нічого публікувати."


### PR DESCRIPTION
Автоматична публікація пакета при пуші в `main` — замість ручного `npm run release`.

## ⚠️ Потрібна дія перед мержем

**У репозиторії немає жодного секрету, зокрема `NPM_TOKEN`.** Без нього воркфлоу дійде до кроку публікації й впаде.

Треба (потрібні права адміна на репо — у мене лише `WRITE`):
1. Створити npm-токен типу **Automation** для акаунта, що має право публікувати в `@skyservice-developers`
2. `Settings → Secrets and variables → Actions → New repository secret`, ім'я — `NPM_TOKEN`

## Як працює

- Тригер: пуш у `main` (плюс ручний запуск через `workflow_dispatch`)
- `paths-ignore` на `**.md` і `.github/**` — правки доків і самого CI не смикають публікацію
- **Перевірка версії перед публікацією:** у `main` прилітають і коміти без релізу. Без цієї перевірки `npm publish` падав би з `EPUBLISHCONFLICT` на кожному такому пуші й фарбував історію Actions у червоне. Тепер якщо версія з `package.json` уже в реєстрі — крок просто пропускається.
- Збірку робить сам npm через наявний `prepublishOnly`
- Авторизація — через наявний у репо `.npmrc`, який читає `NPM_TOKEN` з оточення. Окремий `registry-url` у `setup-node` навмисно не задаю, щоб не плодити другий `.npmrc` у домашній теці раннера.

## Реліз після цього

Бампнути версію в `package.json` → змержити в `main`. Все інше саме.

## Можливі доповнення

Свідомо не додавав, щоб не роздувати першу версію — скажіть, якщо треба:
- git-тег на кожен реліз (потребує `permissions: contents: write`)
- GitHub Release з нотатками
- `npm publish --provenance` (потребує `permissions: id-token: write`)