### PR TITLE
ci: drop npm cache and use npm install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # Без cache: npm — lock-файл навмисно в .gitignore, а кеш setup-node
+      # без нього падає ("Dependencies lock file is not found").
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: npm
 
       # У main прилітають і коміти без релізу — доки, рефакторинг, правки CI.
       # Без цієї перевірки npm publish падав би з EPUBLISHCONFLICT на кожному
@@ -40,9 +41,10 @@ jobs:
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # npm install, а не npm ci — останній вимагає lock-файл у репозиторії.
       - name: Install dependencies
         if: steps.check.outputs.should_publish == 'true'
-        run: npm ci
+        run: npm install
 
       # Збірку робить сам npm через prepublishOnly.
       # Авторизація — через .npmrc у репо, який читає NPM_TOKEN з оточення.


### PR DESCRIPTION
Правка воркфлоу з #9 — перший прогін впав.

## Що сталось

```
##[error]Dependencies lock file is not found in /home/runner/work/vue-dev-kit/vue-dev-kit.
Supported file patterns: package-lock.json, npm-shrinkwrap.json, yarn.lock
```

`package-lock.json` у цьому репозиторії **навмисно в `.gitignore`** (рядок 3). Я перевірив, що файл є на диску, але не те, чи він трекається — тому заклав `cache: npm` і `npm ci`, які без lock-файлу в репо працювати не можуть.

## Виправлення

- прибрано `cache: npm` із `setup-node`
- `npm ci` → `npm install`

Обидві причини записані коментарями у файлі, щоб їх не повернули назад.

## Після мержу

Цей PR чіпає лише `.github/**`, тобто під `paths-ignore` — публікацію він не тригерне. `2.10.1` доведеться випустити вручну через **Actions → Publish to npm → Run workflow** (`workflow_dispatch` у воркфлоу є). Далі все піде саме.