### PR TITLE
feat(filters): SkyFilterDropdown shell + SkySelectFilter (2.14.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ import {
   SkyTableRoot, SkyTableHeader, SkyTableHead, SkyTableBody, SkyTableRow, SkyTableCell,
   useTableSort, useTableSelection, useColumnVisibility,
   FunctionalCalendar, SkyDateRangePicker,
+  SkyFilterDropdown,
   // widgets
   SkyTileCard,
   // features
-  SkyCheckboxFilter,
+  SkyCheckboxFilter, SkySelectFilter,
   TableMassActions, TableColumnSettings, TableVirtualBody,
   // sdk
   navigate, SkyserviceAPI, isInsideIframe,
@@ -1110,7 +1111,7 @@ const range = reactive({ start: '', end: '' }) // { start, end } у формат
 
 ### SkyCheckboxFilter
 
-Кнопка-фільтр з дропдауном, пошуком і мульти-вибором (через `SkyCheckbox`). Лочить скрол сторінки, поки відкритий. Стилі повторюють адмінку Skymarket 1:1.
+Кнопка-фільтр з дропдауном, пошуком і мульти-вибором (через `SkyCheckbox`). Оболонку — тригер, панель, позиціювання, закриття — тримає `SkyFilterDropdown`. Стилі повторюють адмінку Skymarket 1:1.
 
 ```vue
 <SkyCheckboxFilter
@@ -1135,6 +1136,77 @@ const range = reactive({ start: '', end: '' }) // { start, end } у формат
 | `doneLabel` | `String` | `'Готово'` | Лейбл кнопки "Готово" |
 | `searchPlaceholder` | `String` | `'Пошук'` | Placeholder пошуку |
 | `disabled` | `Boolean` | `false` | Вимкнений стан |
+
+### SkySelectFilter
+
+Той самий фільтр-чіп, але з **одиничним** вибором — для випадків, коли бекенд приймає рівно
+одне значення. Після вибору дропдаун закривається.
+
+```vue
+<SkySelectFilter
+  v-model="categoryId"
+  title="Категорія"
+  all-label="Усі категорії"
+  :options="[
+    { value: 10, name: 'Напої', depth: 0 },
+    { value: 11, name: 'Кава', depth: 1 },
+  ]"
+/>
+```
+
+#### Props
+
+| Prop | Тип | За замовчуванням | Опис |
+|------|-----|------------------|------|
+| `title` | `String` | — | Заголовок фільтра (показується у тригері) |
+| `options` | `Array<{ value, name, depth? }>` | — | Опції; `depth` лише відступає рядок |
+| `modelValue` | `String\|Number\|null` | `null` | Обране значення (v-model); `null` — фільтр вимкнено |
+| `allLabel` | `String` | `''` | Лейбл рядка «без фільтра»; порожній — рядка немає |
+| `searchPlaceholder` | `String` | `'Пошук'` | Placeholder пошуку |
+| `emptyLabel` | `String` | `'Нічого не знайдено'` | Текст порожнього результату пошуку |
+| `searchable` | `Boolean` | `true` | Показувати поле пошуку |
+| `disabled` | `Boolean` | `false` | Вимкнений стан |
+
+---
+
+## SkyFilterDropdown
+
+Оболонка фільтра: тригер-чіп + панель. Бере на себе тільки спільне — стан відкриття,
+позиціювання, закриття і доступність; вміст панелі за викликачем. На ній побудовані
+`SkyCheckboxFilter` і `SkySelectFilter`; бери її напряму для фільтра з власним вмістом.
+
+Панель телепортується у `<body>` (щоб `transform` у предка не ламав `position: fixed`),
+перепозиціюється на скрол і resize, притискається до країв екрана й розкривається вгору,
+коли знизу тісно. Скрол сторінки **не** локиться. Закриття — клік поза межами, `Esc`.
+
+```vue
+<SkyFilterDropdown title="Період" summary="Цей тиждень">
+  <template #default="{ close }">
+    <button @click="close">Готово</button>
+  </template>
+</SkyFilterDropdown>
+```
+
+#### Props
+
+| Prop | Тип | За замовчуванням | Опис |
+|------|-----|------------------|------|
+| `title` | `String` | — | Лейбл чіпа |
+| `summary` | `String` | `''` | Заміняє `title`, коли обрано рівно одне |
+| `badge` | `String\|Number` | `''` | Показується поруч із `title` (напр. лічильник) |
+| `align` | `'start'\|'end'` | `'start'` | До якого краю тригера притискається панель |
+| `width` | `Number` | `280` | Ширина панелі в px |
+| `disabled` | `Boolean` | `false` | Вимкнений стан |
+
+#### Slots / Events / Expose
+
+| | |
+|---|---|
+| slot `default` | `{ close }` — вміст панелі |
+| events | `open`, `close` |
+| expose | `open()`, `close()`, `toggle()`, `isOpen` |
+
+CSS-змінні (`--sky-filter-*`) — див. [доки](https://74cfe434-a2b3-4d49-8fa7-db7343e399dc.apps.platform365.online/components/sky-filter-dropdown).
 
 ---
 
@@ -1287,6 +1359,7 @@ src/
 │       ├── table/       # примітиви композиційної таблиці (Root/Header/Head/Body/Row/Cell/Empty)
 │       ├── SkyTable/     # готова віртуал-скрол таблиця (Header/Row/Footer/DynamicScroller/items/*)
 │       ├── SkyTileCard/
+│       ├── SkyFilterDropdown/  # оболонка фільтра (тригер + панель) + FilterSearch
 │       ├── functional-calendar/ # форк vue-functional-calendar, перенесений зі SkyMarket 1:1
 │       ├── SkyDateRangePicker/  # DatePickerRange зі SkyMarket, store/langs → props/локальний стан
 │       └── <Component>/
@@ -1296,7 +1369,8 @@ src/
 │       └── table/   # skyTableFeatures + useTableSort / useTableSelection / useColumnVisibility
 ├── features/          # фічові блоки (orchestration shared/ui)
 │   ├── index.ts
-│   ├── SkyCheckboxFilter/
+│   ├── SkyCheckboxFilter/  # мульти-вибір на SkyFilterDropdown
+│   ├── SkySelectFilter/    # одиничний вибір на SkyFilterDropdown
 │   ├── table/         # TableMassActions / TableColumnSettings / TableVirtualBody
 │   └── data-table/    # SkyDataTable на TanStack v9 + перемикач колонок
 ├── sdk/               # TypeScript SDK (без Vue залежностей)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -155,8 +155,16 @@ export default defineConfig({
           collapsed: false,
           items: [
             {
+              text: 'SkyFilterDropdown',
+              link: '/components/sky-filter-dropdown',
+            },
+            {
               text: 'SkyCheckboxFilter',
               link: '/components/sky-checkbox-filter',
+            },
+            {
+              text: 'SkySelectFilter',
+              link: '/components/sky-select-filter',
             },
           ],
         },

--- a/docs/.vitepress/theme/ComponentGallery.vue
+++ b/docs/.vitepress/theme/ComponentGallery.vue
@@ -19,6 +19,7 @@ import Modal from '@/shared/ui/Modal/Modal.vue'
 import Dialog from '@/shared/ui/Dialog/Dialog.vue'
 import Header from '@/shared/ui/Header/Header.vue'
 import SkyCheckboxFilter from '@/features/SkyCheckboxFilter/SkyCheckboxFilter.vue'
+import SkySelectFilter from '@/features/SkySelectFilter/SkySelectFilter.vue'
 import SkyDataTable from '@/features/data-table/SkyDataTable.vue'
 import SkyTableRoot from '@/shared/ui/table/SkyTableRoot.vue'
 import SkyTableHeader from '@/shared/ui/table/SkyTableHeader.vue'
@@ -35,6 +36,7 @@ const selectSearch = ref('')
 const checked = ref(true)
 const period = ref('week')
 const filter = ref([])
+const selectFilter = ref(null)
 const showModal = ref(false)
 const showDialog = ref(false)
 
@@ -166,6 +168,25 @@ const primitiveColumns = [
           <SkyCheckboxFilter
             v-model="filter"
             title="Категорії"
+            :options="[
+              { value: 'drinks', name: 'Напої' },
+              { value: 'food', name: 'Їжа' },
+            ]"
+          />
+        </div>
+      </article>
+
+      <article class="vdk-card">
+        <header class="vdk-card__head">
+          <a href="/components/sky-select-filter">SkySelectFilter</a>
+          <code>одиничний вибір</code>
+        </header>
+        <div class="vdk-card__stage">
+          <SkySelectFilter
+            v-model="selectFilter"
+            title="Категорія"
+            all-label="Усі категорії"
+            :searchable="false"
             :options="[
               { value: 'drinks', name: 'Напої' },
               { value: 'food', name: 'Їжа' },

--- a/docs/.vitepress/theme/demos/SkySelectFilterDemo.vue
+++ b/docs/.vitepress/theme/demos/SkySelectFilterDemo.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { ref } from 'vue'
+import SkySelectFilter from '@/features/SkySelectFilter/SkySelectFilter.vue'
+
+const category = ref(null)
+const status = ref('active')
+
+// depth лише відступає рядок — фільтр завжди точний, підкатегорії не розгортаються
+const categoryOptions = [
+  { value: 10, name: 'Напої', depth: 0 },
+  { value: 11, name: 'Кава', depth: 1 },
+  { value: 12, name: 'Чай', depth: 1 },
+  { value: 20, name: 'Їжа', depth: 0 },
+  { value: 21, name: 'Випічка', depth: 1 },
+  { value: 22, name: 'Сніданки', depth: 1 },
+  { value: 0, name: 'Без категорії', depth: 0 },
+]
+const statusOptions = [
+  { value: 'active', name: 'Активний' },
+  { value: 'paused', name: 'Призупинений' },
+  { value: 'archived', name: 'Архівний' },
+]
+</script>
+
+<template>
+  <Demo title="Одиничний вибір: дерево + плаский список" column>
+    <div class="vdk-filters">
+      <SkySelectFilter
+        v-model="category"
+        title="Категорія"
+        all-label="Усі категорії"
+        :options="categoryOptions"
+      />
+      <SkySelectFilter
+        v-model="status"
+        title="Статус"
+        :options="statusOptions"
+        :searchable="false"
+      />
+      <SkySelectFilter title="Disabled" :options="statusOptions" disabled />
+    </div>
+    <span class="vdk-demo-out">категорія: {{ category ?? '—' }} · статус: {{ status }}</span>
+  </Demo>
+</template>
+
+<style scoped>
+.vdk-filters {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+</style>

--- a/docs/components/sky-checkbox-filter.md
+++ b/docs/components/sky-checkbox-filter.md
@@ -1,6 +1,6 @@
 # SkyCheckboxFilter
 
-Кнопка-фільтр із дропдауном, пошуком і мульти-вибором (на базі [`SkyCheckbox`](/components/sky-checkbox)). Лочить скрол сторінки, поки відкритий. Стилі повторюють адмінку Skymarket 1:1.
+Кнопка-фільтр із дропдауном, пошуком і мульти-вибором (на базі [`SkyCheckbox`](/components/sky-checkbox)). Оболонку — тригер, панель, позиціювання, закриття — тримає [`SkyFilterDropdown`](/components/sky-filter-dropdown). Стилі повторюють адмінку Skymarket 1:1.
 
 ## Демо
 
@@ -64,8 +64,11 @@ interface FilterOption {
 - **тригер-кнопка** з `title` і лічильником обраного;
 - **дропдаун** з пошуком по `name`;
 - **мульти-вибір** через `SkyCheckbox` (array-режим);
-- кнопки **«Вибрати всі» / «Очистити» / «Готово»**;
-- **лок скролу** сторінки, поки дропдаун відкритий.
+- кнопки **«Вибрати всі» / «Очистити» / «Готово»**.
+
+Позиціювання, закриття по `Esc` / кліку поза межами та доступність приходять з
+[`SkyFilterDropdown`](/components/sky-filter-dropdown). Скрол сторінки більше **не**
+локиться: панель перепозиціюється на скрол, тож блокувати сторінку немає потреби.
 
 ## Кілька фільтрів поруч
 
@@ -90,5 +93,7 @@ const filterStatus = ref([])
 
 ## Пов'язане
 
+- [SkyFilterDropdown](/components/sky-filter-dropdown) — оболонка тригер + панель.
+- [SkySelectFilter](/components/sky-select-filter) — той самий фільтр, але з одиничним вибором.
 - [SkyCheckbox](/components/sky-checkbox) — базовий чекбокс, на якому побудований фільтр.
-- [SkySelectSearch](/components/sky-select-search) — коли потрібен одиничний вибір із пошуком.
+- [SkySelectSearch](/components/sky-select-search) — коли потрібне поле форми, а не фільтр-чіп.

--- a/docs/components/sky-filter-dropdown.md
+++ b/docs/components/sky-filter-dropdown.md
@@ -1,0 +1,85 @@
+# SkyFilterDropdown
+
+Оболонка фільтра: тригер-чіп + панель. Бере на себе тільки те, що спільне для всіх фільтрів — стан відкриття, позиціювання, закриття і доступність. Вміст панелі повністю за викликачем.
+
+На ній побудовані [`SkyCheckboxFilter`](/components/sky-checkbox-filter) і [`SkySelectFilter`](/components/sky-select-filter). Бери її напряму, коли потрібен фільтр із власним вмістом — календар, дерево, слайдер діапазону.
+
+## Що вона робить
+
+- **Панель телепортується у `<body>`.** Інакше будь-який предок із `transform` / `filter` / `contain` ламає `position: fixed`.
+- **Позиція перераховується на скрол і resize.** Панель прив'язана до тригера й не «відклеюється». Саме тому тут **немає лока скролу сторінки** — його не треба.
+- **Панель не вилазить за екран:** притискається до країв, а якщо знизу тісно — розкривається вгору. Власну висоту обмежує сама, тож скролиться список усередині, а не сторінка.
+- **Закриття:** клік поза межами, `Esc` (фокус повертається на тригер), `disabled` на льоту.
+- **Доступність:** тригер — справжній `<button>` з `aria-haspopup` та `aria-expanded`, панель — `role="dialog"` з `aria-label`.
+- **Слухачі живуть лише поки панель відкрита** — сторінка з десятком фільтрів не тримає десяток слухачів `document`.
+
+## Приклад
+
+```vue
+<script setup>
+import { SkyFilterDropdown } from '@skyservice-developers/vue-dev-kit'
+</script>
+
+<template>
+  <SkyFilterDropdown title="Період" summary="Цей тиждень">
+    <template #default="{ close }">
+      <!-- будь-який вміст -->
+      <button @click="close">Готово</button>
+    </template>
+  </SkyFilterDropdown>
+</template>
+```
+
+## Props
+
+| Prop | Тип | За замовчуванням | Опис |
+|------|-----|------------------|------|
+| `title` | `String` | — | Лейбл чіпа |
+| `summary` | `String` | `''` | Заміняє `title`, коли обрано рівно одне (напр. назва опції) |
+| `badge` | `String \| Number` | `''` | Показується поруч із `title` (напр. кількість обраного) |
+| `align` | `'start' \| 'end'` | `'start'` | До якого краю тригера притискається панель, поки вміщається |
+| `width` | `Number` | `280` | Ширина панелі в px; більшу за екран не візьме |
+| `disabled` | `Boolean` | `false` | Вимкнений стан; відкрита панель закривається |
+
+## Slots
+
+| Slot | Props | Опис |
+|------|-------|------|
+| `default` | `{ close }` | Вміст панелі. `close()` — закрити ззовні (напр. після вибору) |
+
+## Events
+
+| Event | Коли |
+|-------|------|
+| `open` | Панель відкрилась |
+| `close` | Панель закрилась (будь-яким способом) |
+
+## Expose
+
+`open()`, `close()`, `toggle()`, `isOpen` — коли фільтром треба керувати ззовні.
+
+## CSS-змінні
+
+| Змінна | За замовчуванням | Опис |
+|--------|------------------|------|
+| `--sky-filter-trigger-height` | `38px` | Висота чіпа |
+| `--sky-filter-trigger-padding` | `0 10px` | Падінги чіпа |
+| `--sky-filter-trigger-border-color` | `#ced4da` | Бордер чіпа |
+| `--sky-filter-trigger-radius` | `5px` | Радіус чіпа |
+| `--sky-filter-trigger-bg` | `transparent` | Фон чіпа |
+| `--sky-filter-trigger-color` | `inherit` | Колір тексту чіпа |
+| `--sky-filter-trigger-font-size` | `12pt` | Розмір тексту чіпа |
+| `--sky-filter-trigger-font-weight` | `500` | Насиченість тексту чіпа |
+| `--sky-filter-trigger-muted-color` | `#b4b4b4` | Колір відкритого / вимкненого чіпа |
+| `--sky-filter-badge-color` | `gray` | Колір бейджа |
+| `--sky-filter-panel-bg` | `#fff` | Фон панелі |
+| `--sky-filter-panel-radius` | `5px` | Радіус панелі |
+| `--sky-filter-panel-padding` | `10px 15px` | Падінги панелі |
+| `--sky-filter-panel-shadow` | `0 5px 8px rgba(0, 0, 0, 0.3)` | Тінь панелі |
+| `--sky-filter-panel-z-index` | `1000` | z-index панелі |
+| `--sky-filter-accent` | `#106090` | Акцент: фокус, лінки, обраний рядок |
+
+## Пов'язане
+
+- [SkyCheckboxFilter](/components/sky-checkbox-filter) — мульти-вибір на цій оболонці.
+- [SkySelectFilter](/components/sky-select-filter) — одиничний вибір на цій оболонці.

--- a/docs/components/sky-select-filter.md
+++ b/docs/components/sky-select-filter.md
@@ -1,0 +1,86 @@
+# SkySelectFilter
+
+Кнопка-фільтр із дропдауном і **одиничним** вибором — сестра [`SkyCheckboxFilter`](/components/sky-checkbox-filter) для випадків, коли бекенд приймає рівно одне значення. Обидві побудовані на [`SkyFilterDropdown`](/components/sky-filter-dropdown), тож візуал адмінки в них спільний.
+
+## Демо
+
+<ClientOnly>
+  <SkySelectFilterDemo />
+</ClientOnly>
+
+Це **feature**-компонент — складений блок, що оркеструє кілька базових компонентів.
+
+## Приклад
+
+```vue
+<script setup>
+import { ref } from 'vue'
+import { SkySelectFilter } from '@skyservice-developers/vue-dev-kit'
+
+const categoryId = ref(null)
+const categories = [
+  { value: 10, name: 'Напої', depth: 0 },
+  { value: 11, name: 'Кава', depth: 1 },
+  { value: 12, name: 'Чай', depth: 1 },
+]
+</script>
+
+<template>
+  <SkySelectFilter
+    v-model="categoryId"
+    title="Категорія"
+    all-label="Усі категорії"
+    :options="categories"
+  />
+</template>
+```
+
+## Props
+
+| Prop | Тип | За замовчуванням | Опис |
+|------|-----|------------------|------|
+| `title` | `String` | — | Заголовок фільтра; показується у тригері, поки нічого не обрано |
+| `options` | `Array<{ value, name, depth? }>` | — | Опції для вибору |
+| `modelValue` | `String \| Number \| null` | `null` | Обране значення (v-model); `null` — фільтр вимкнено |
+| `allLabel` | `String` | `''` | Лейбл першого рядка «без фільтра». Порожній — рядок не показується |
+| `searchPlaceholder` | `String` | `'Пошук'` | Placeholder пошуку |
+| `emptyLabel` | `String` | `'Нічого не знайдено'` | Текст, коли пошук нічого не знайшов |
+| `searchable` | `Boolean` | `true` | Показувати поле пошуку |
+| `disabled` | `Boolean` | `false` | Вимкнений стан |
+
+## Events
+
+| Event | Payload | Коли |
+|-------|---------|------|
+| `update:modelValue` | `String \| Number \| null` | Обрано опцію або рядок «без фільтра». Дропдаун одразу закривається |
+
+## Формат опцій
+
+```ts
+interface FilterOption {
+  value: string | number  // потрапляє в v-model
+  name: string            // показується користувачу, за ним іде пошук
+  depth?: number          // рівень вкладеності: лише відступ рядка
+}
+```
+
+`depth` **нічого не фільтрує** — вибір завжди точний, підкатегорії не розгортаються.
+Якщо потрібне «разом із вкладеними», це має бути окремий вибір користувача, а розкриття
+робить бекенд.
+
+## CSS-змінні
+
+Спільні з рештою фільтрів — див. [`SkyFilterDropdown`](/components/sky-filter-dropdown#css-змінні). Додатково:
+
+| Змінна | За замовчуванням | Опис |
+|--------|------------------|------|
+| `--sky-filter-option-hover-bg` | `rgba(0, 0, 0, 0.05)` | Фон рядка під курсором |
+| `--sky-filter-option-selected-bg` | `rgba(16, 96, 144, 0.1)` | Фон обраного рядка |
+| `--sky-filter-accent` | `#106090` | Колір обраного рядка й фокусу пошуку |
+| `--sky-filter-muted-color` | `#adb5bd` | Колір тексту «нічого не знайдено» |
+
+## Пов'язане
+
+- [SkyFilterDropdown](/components/sky-filter-dropdown) — оболонка тригер + панель.
+- [SkyCheckboxFilter](/components/sky-checkbox-filter) — той самий фільтр, але з мульти-вибором.
+- [SkySelectSearch](/components/sky-select-search) — коли потрібне поле форми, а не фільтр-чіп.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.13.4",
+  "version": "2.14.0",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
+++ b/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { computed, ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue';
+import { computed, ref } from 'vue';
 import SkyCheckbox from '@/shared/ui/SkyCheckbox/SkyCheckbox.vue';
+import SkyFilterDropdown from '@/shared/ui/SkyFilterDropdown/SkyFilterDropdown.vue';
+import FilterSearch from '@/shared/ui/SkyFilterDropdown/FilterSearch.vue';
 
 type OptionValue = string | number;
 
@@ -34,9 +36,6 @@ const emit = defineEmits<{
   'update:modelValue': [OptionValue[]];
 }>();
 
-const triggerRef = ref<HTMLDivElement | null>(null);
-const dropdownStyle = ref<Record<string, string>>({});
-const isOpen = ref(false);
 const searchQuery = ref('');
 
 const filteredOptions = computed(() => {
@@ -50,6 +49,7 @@ const selected = computed({
   set: (v) => emit('update:modelValue', v),
 });
 
+/** One pick reads better as the option's own name than as "Title: 1". */
 const oneSelectedLabel = computed(() => {
   if (selected.value.length !== 1) return '';
   const found = props.options.find((o) => o.value === selected.value[0]);
@@ -57,302 +57,96 @@ const oneSelectedLabel = computed(() => {
   return found.name.length < 20 ? found.name : found.name.slice(0, 20) + '...';
 });
 
-function toggle() {
-  if (props.disabled) return;
-  if (isOpen.value) {
-    close();
-    return;
-  }
-  open();
-}
+const triggerSummary = computed(() => oneSelectedLabel.value);
+const triggerBadge = computed(() => (selected.value.length > 1 ? selected.value.length : ''));
 
-function open() {
-  isOpen.value = true;
-  searchQuery.value = '';
-  nextTick(() => {
-    const el = triggerRef.value;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    dropdownStyle.value = {
-      left: `${rect.left}px`,
-      top: `${rect.bottom + 5}px`,
-    };
-  });
-}
-
-function close() {
-  isOpen.value = false;
-  searchQuery.value = '';
-}
-
-function selectAll() {
+function selectAll(): void {
   selected.value = props.options.map((o) => o.value);
 }
 
-function clearAll() {
+function clearAll(): void {
   selected.value = [];
 }
-
-function clearSearch() {
-  searchQuery.value = '';
-}
-
-function onDocumentClick(e: MouseEvent) {
-  if (!isOpen.value) return;
-  const target = e.target as Node;
-  if (triggerRef.value?.contains(target)) return;
-  const dropdown = document.querySelector('.sky-checkbox-filter__dropdown');
-  if (dropdown && dropdown.contains(target)) return;
-  close();
-}
-
-let prevBodyOverflow = '';
-
-watch(isOpen, (open) => {
-  if (open) {
-    prevBodyOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-  } else {
-    document.body.style.overflow = prevBodyOverflow;
-  }
-});
-
-onMounted(() => document.addEventListener('click', onDocumentClick));
-onBeforeUnmount(() => {
-  document.removeEventListener('click', onDocumentClick);
-  if (isOpen.value) document.body.style.overflow = prevBodyOverflow;
-});
 </script>
 
 <template>
-  <div class="sky-checkbox-filter">
-    <div
-      ref="triggerRef"
-      :class="[
-        'header-filter-block',
-        { 'hf-check': isOpen, 'hf-disabled': disabled },
-      ]"
-      @click="toggle"
-    >
-      <span v-if="selected.length === 1" class="header-filter-block__title">
-        {{ oneSelectedLabel || title }}
-      </span>
-      <span v-else class="header-filter-block__title">
-        {{ title }}{{ selected.length > 0 ? ':' : '' }}
-      </span>
-      <div
-        v-if="!disabled && selected.length > 1"
-        class="header-filter-block__count"
-      >
-        {{ selected.length }}
+  <SkyFilterDropdown
+    class="sky-checkbox-filter"
+    :title="title"
+    :summary="triggerSummary"
+    :badge="triggerBadge"
+    :disabled="disabled"
+    @open="searchQuery = ''"
+    @close="searchQuery = ''"
+  >
+    <template #default="{ close }">
+      <div class="sky-checkbox-filter__actions">
+        <button type="button" class="sky-checkbox-filter__link" @click="selectAll">
+          {{ selectAllLabel }}
+        </button>
+        <button type="button" class="sky-checkbox-filter__link" @click="clearAll">
+          {{ clearLabel }}
+        </button>
       </div>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        class="sol-caret"
-      >
-        <path d="m6 9 6 6 6-6" />
-      </svg>
-    </div>
 
-    <transition name="fade-select">
-      <div
-        v-if="isOpen"
-        class="selectColumn selectHeaderFilter sky-checkbox-filter__dropdown"
-        :style="dropdownStyle"
-      >
-        <div class="dialog-buttons">
-          <span style="cursor: pointer" @click="selectAll">{{
-            selectAllLabel
-          }}</span>
-          <span style="cursor: pointer" @click="clearAll">{{
-            clearLabel
-          }}</span>
-        </div>
-        <div class="filtersCurtain__innerWrap_middle">
-          <input
-            v-model="searchQuery"
-            class="searchInput"
-            type="text"
-            :placeholder="searchPlaceholder"
-          />
-          <i
-            v-if="searchQuery.trim()"
-            class="filtersCurtain__innerWrap_middleIcon"
-            @click="clearSearch"
-            >×</i
-          >
-        </div>
+      <FilterSearch v-model="searchQuery" :placeholder="searchPlaceholder" :label="title" />
 
-        <div class="sky-checkbox-filter__options">
-          <div
-            v-for="opt in filteredOptions"
-            :key="opt.value"
-            class="filter-option"
-          >
-            <SkyCheckbox v-model="selected" :value="opt.value">
-              {{ opt.name }}
-            </SkyCheckbox>
-          </div>
-        </div>
-
-        <hr style="margin-top: 0; margin-bottom: 2px" />
-        <div class="dialog-buttons" style="padding-top: 10px; padding-bottom: 0">
-          <span style="cursor: pointer" @click="close">{{ doneLabel }}</span>
+      <div class="sky-checkbox-filter__options">
+        <div v-for="opt in filteredOptions" :key="opt.value" class="sky-checkbox-filter__option">
+          <SkyCheckbox v-model="selected" :value="opt.value">{{ opt.name }}</SkyCheckbox>
         </div>
       </div>
-    </transition>
-  </div>
+
+      <hr class="sky-checkbox-filter__sep" />
+      <div class="sky-checkbox-filter__actions sky-checkbox-filter__actions--footer">
+        <button type="button" class="sky-checkbox-filter__link" @click="close">
+          {{ doneLabel }}
+        </button>
+      </div>
+    </template>
+  </SkyFilterDropdown>
 </template>
 
 <style scoped>
-.sky-checkbox-filter {
-  display: inline-block;
-}
-
-.header-filter-block {
-  border: none !important;
-  position: relative;
+.sky-checkbox-filter__actions {
   display: flex;
-  white-space: nowrap;
-  line-height: 38px;
-  cursor: pointer;
-  padding: 0 10px;
-  height: 38px;
-  font-size: 16px;
-  border: 1px solid #ced4da;
-  border-radius: 5px;
-}
-
-.header-filter-block__title {
-  font-size: 12pt;
-  font-weight: 500;
-}
-
-.header-filter-block__count {
-  margin-top: 1px;
-  font-size: 12px;
-  margin-left: 4px;
-  color: gray;
-}
-
-.sol-caret {
-  margin-left: 4px;
-  transition: transform 0.2s ease-in-out;
   flex-shrink: 0;
-  align-self: center;
-}
-
-.hf-check,
-.hf-disabled {
-  color: #b4b4b4;
-}
-
-.hf-check > .sol-caret {
-  transform: rotate(180deg);
-}
-
-.hf-disabled {
-  cursor: default;
-}
-
-.hf-disabled > .sol-caret {
-  opacity: 0.5;
-}
-
-/* Dropdown */
-.selectColumn.selectHeaderFilter {
-  position: fixed;
-  z-index: 1000;
-  padding: 10px 15px;
-  border-radius: 5px;
-  background: white;
-  box-shadow: 0 5px 8px rgba(0, 0, 0, 0.3);
-  min-width: 280px;
-}
-
-.dialog-buttons {
-  display: flex;
   justify-content: space-between;
   padding: 8px 0;
   font-size: 13px;
-  color: #106090;
 }
 
-.dialog-buttons span:hover {
+.sky-checkbox-filter__actions--footer {
+  padding: 10px 0 0;
+}
+
+.sky-checkbox-filter__link {
+  padding: 0;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: var(--sky-filter-accent, #106090);
+  cursor: pointer;
+}
+
+.sky-checkbox-filter__link:hover {
   text-decoration: underline;
 }
 
-.filtersCurtain__innerWrap_middle {
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  margin-bottom: 15px;
-  border-bottom: #d3d3d3 solid 2px;
-  padding-left: unset;
-}
-
-.searchInput {
-  margin: 0;
-  outline: none;
-  border: none;
-  flex-grow: 2;
-  font-size: 12px;
-  padding: 4px 24px 4px 0;
-  background: transparent;
-  width: 100%;
-}
-
-.filtersCurtain__innerWrap_middle:has(.searchInput:focus) {
-  transition: all 200ms;
-  border-bottom: #106090 solid 2px;
-}
-
-.filtersCurtain__innerWrap_middleIcon {
-  position: absolute;
-  font-size: 16px;
-  font-style: normal;
-  right: 5px;
-  top: 0;
-  color: #adb5bd;
-  cursor: pointer;
-  line-height: 1;
-}
-
+/* The panel caps its own height, so the option list is what scrolls inside it. */
 .sky-checkbox-filter__options {
-  max-height: 250px;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
 }
 
-.filter-option {
+.sky-checkbox-filter__option {
   padding: 0 4px;
   margin-bottom: 5px;
 }
 
-/* Transition */
-.fade-select-enter-active {
-  animation: fade-select-in 0.2s;
-}
-
-.fade-select-leave-active {
-  animation: fade-select-in 0.2s reverse;
-}
-
-@keyframes fade-select-in {
-  0% {
-    transform: translate3d(0, -10px, 0);
-    opacity: 0;
-  }
-  100% {
-    transform: translate3d(0, 0, 0);
-    opacity: 1;
-  }
+.sky-checkbox-filter__sep {
+  flex-shrink: 0;
+  margin: 0 0 2px;
 }
 </style>

--- a/src/features/SkySelectFilter/SkySelectFilter.vue
+++ b/src/features/SkySelectFilter/SkySelectFilter.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import SkyFilterDropdown from '@/shared/ui/SkyFilterDropdown/SkyFilterDropdown.vue';
+import FilterSearch from '@/shared/ui/SkyFilterDropdown/FilterSearch.vue';
+
+type OptionValue = string | number;
+
+interface Option {
+  value: OptionValue;
+  name: string;
+  /** Nesting level for tree-shaped lists; indents the row, nothing more. */
+  depth?: number;
+}
+
+const props = withDefaults(
+  defineProps<{
+    title: string;
+    options: Option[];
+    /** `null` — nothing picked, i.e. the filter is off. */
+    modelValue?: OptionValue | null;
+    /** Label of the leading "no filter" row; omit to hide that row. */
+    allLabel?: string;
+    searchPlaceholder?: string;
+    emptyLabel?: string;
+    searchable?: boolean;
+    disabled?: boolean;
+  }>(),
+  {
+    modelValue: null,
+    allLabel: '',
+    searchPlaceholder: 'Пошук',
+    emptyLabel: 'Нічого не знайдено',
+    searchable: true,
+    disabled: false,
+  },
+);
+
+const emit = defineEmits<{
+  'update:modelValue': [OptionValue | null];
+}>();
+
+const searchQuery = ref('');
+
+const filteredOptions = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase();
+  if (!q) return props.options;
+  return props.options.filter((o) => o.name.toLowerCase().includes(q));
+});
+
+const selectedOption = computed(() =>
+  props.modelValue == null ? undefined : props.options.find((o) => o.value === props.modelValue),
+);
+
+/** The trigger shows the pick itself; falling back to the title when nothing is picked. */
+const triggerSummary = computed(() => {
+  const name = selectedOption.value?.name;
+  if (!name) return '';
+  return name.length < 20 ? name : name.slice(0, 20) + '...';
+});
+
+function pick(value: OptionValue | null, close: () => void): void {
+  emit('update:modelValue', value);
+  close();
+}
+</script>
+
+<template>
+  <SkyFilterDropdown
+    class="sky-select-filter"
+    :title="title"
+    :summary="triggerSummary"
+    :disabled="disabled"
+    @open="searchQuery = ''"
+    @close="searchQuery = ''"
+  >
+    <template #default="{ close }">
+      <FilterSearch
+        v-if="searchable"
+        v-model="searchQuery"
+        :placeholder="searchPlaceholder"
+        :label="title"
+      />
+
+      <div class="sky-select-filter__options" role="listbox" :aria-label="title">
+        <button
+          v-if="allLabel && !searchQuery.trim()"
+          type="button"
+          role="option"
+          class="sky-select-filter__option"
+          :class="{ 'is-selected': modelValue == null }"
+          :aria-selected="modelValue == null"
+          @click="pick(null, close)"
+        >
+          {{ allLabel }}
+        </button>
+
+        <button
+          v-for="opt in filteredOptions"
+          :key="opt.value"
+          type="button"
+          role="option"
+          class="sky-select-filter__option"
+          :class="{ 'is-selected': opt.value === modelValue }"
+          :aria-selected="opt.value === modelValue"
+          :style="{ paddingLeft: `${8 + (opt.depth ?? 0) * 14}px` }"
+          @click="pick(opt.value, close)"
+        >
+          {{ opt.name }}
+        </button>
+
+        <p v-if="!filteredOptions.length" class="sky-select-filter__empty">{{ emptyLabel }}</p>
+      </div>
+    </template>
+  </SkyFilterDropdown>
+</template>
+
+<style scoped>
+/* The panel caps its own height, so the option list is what scrolls inside it. */
+.sky-select-filter__options {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  margin: 0 -5px;
+}
+
+.sky-select-filter__option {
+  display: block;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  font: inherit;
+  font-size: 14px;
+  color: inherit;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.sky-select-filter__option:hover {
+  background: var(--sky-filter-option-hover-bg, rgba(0, 0, 0, 0.05));
+}
+
+.sky-select-filter__option.is-selected {
+  background: var(--sky-filter-option-selected-bg, rgba(16, 96, 144, 0.1));
+  color: var(--sky-filter-accent, #106090);
+  font-weight: 500;
+}
+
+.sky-select-filter__empty {
+  margin: 0;
+  padding: 8px;
+  font-size: 13px;
+  color: var(--sky-filter-muted-color, #adb5bd);
+}
+</style>

--- a/src/features/SkySelectFilter/index.ts
+++ b/src/features/SkySelectFilter/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SkySelectFilter.vue';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,3 +1,4 @@
 export { default as SkyCheckboxFilter } from './SkyCheckboxFilter';
+export { default as SkySelectFilter } from './SkySelectFilter';
 export * from './table';
 export * from './data-table';

--- a/src/shared/ui/SkyFilterDropdown/FilterSearch.vue
+++ b/src/shared/ui/SkyFilterDropdown/FilterSearch.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+/**
+ * The underlined search row used inside filter panels. Internal to the filter
+ * family — not exported from the layer index; use SkySearchInput for a standalone
+ * search field.
+ */
+defineProps<{
+  modelValue: string;
+  placeholder?: string;
+  /** Rendered as the field's accessible name (the row has no visible label). */
+  label?: string;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [string];
+}>();
+</script>
+
+<template>
+  <div class="sky-filter-search">
+    <input
+      class="sky-filter-search__input"
+      type="text"
+      :value="modelValue"
+      :placeholder="placeholder"
+      :aria-label="label || placeholder"
+      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    />
+    <button
+      v-if="modelValue.trim()"
+      type="button"
+      class="sky-filter-search__clear"
+      :aria-label="`${label || placeholder} ✕`"
+      @click="emit('update:modelValue', '')"
+    >
+      ×
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.sky-filter-search {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  margin-bottom: 15px;
+  border-bottom: 2px solid var(--sky-filter-search-border-color, #d3d3d3);
+}
+
+.sky-filter-search:has(.sky-filter-search__input:focus) {
+  border-bottom-color: var(--sky-filter-accent, #106090);
+  transition: border-color 200ms;
+}
+
+.sky-filter-search__input {
+  flex-grow: 2;
+  width: 100%;
+  margin: 0;
+  padding: 4px 24px 4px 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 12px;
+  color: inherit;
+}
+
+.sky-filter-search__clear {
+  position: absolute;
+  right: 5px;
+  top: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--sky-filter-muted-color, #adb5bd);
+  cursor: pointer;
+}
+</style>

--- a/src/shared/ui/SkyFilterDropdown/SkyFilterDropdown.vue
+++ b/src/shared/ui/SkyFilterDropdown/SkyFilterDropdown.vue
@@ -1,0 +1,282 @@
+<script setup lang="ts">
+import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
+
+/**
+ * Trigger + popover shell shared by the filter chips (SkyCheckboxFilter,
+ * SkySelectFilter). Owns only the shell concerns — open state, positioning,
+ * dismissal and a11y — the content is entirely up to the caller.
+ */
+const props = withDefaults(
+  defineProps<{
+    /** Chip label, always visible. */
+    title: string;
+    /** Replaces the title when exactly one thing is picked (e.g. the option name). */
+    summary?: string;
+    /** Shown next to the title when several things are picked (e.g. the count). */
+    badge?: string | number;
+    disabled?: boolean;
+    /** Which trigger edge the panel lines up with when it fits. */
+    align?: 'start' | 'end';
+    /** Panel width in px; the panel never grows past the viewport. */
+    width?: number;
+  }>(),
+  {
+    summary: '',
+    badge: '',
+    disabled: false,
+    align: 'start',
+    width: 280,
+  },
+);
+
+const emit = defineEmits<{
+  open: [];
+  close: [];
+}>();
+
+const GAP = 5;
+/** Below this the panel would be too cramped to be useful — flip it above instead. */
+const MIN_PANEL_HEIGHT = 180;
+const EDGE = 8;
+
+const triggerRef = ref<HTMLButtonElement | null>(null);
+const panelRef = ref<HTMLDivElement | null>(null);
+const isOpen = ref(false);
+const panelStyle = ref<Record<string, string>>({});
+
+const label = computed(() => props.summary || props.title);
+const hasBadge = computed(() => !props.disabled && props.badge !== '' && props.badge != null);
+
+/**
+ * Anchors the panel to the trigger. Runs on open and on every scroll/resize while
+ * open — a position frozen at open time drifts as soon as anything scrolls, which
+ * is the reason the old filter had to lock the page scroll instead.
+ */
+function updatePosition(): void {
+  const trigger = triggerRef.value;
+  if (!trigger) return;
+
+  const rect = trigger.getBoundingClientRect();
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  const width = Math.min(props.width, vw - EDGE * 2);
+  const left = props.align === 'end' ? rect.right - width : rect.left;
+
+  const below = vh - rect.bottom - GAP - EDGE;
+  const above = rect.top - GAP - EDGE;
+  const flip = below < MIN_PANEL_HEIGHT && above > below;
+
+  panelStyle.value = {
+    left: `${Math.max(EDGE, Math.min(left, vw - width - EDGE))}px`,
+    width: `${width}px`,
+    maxHeight: `${Math.max(MIN_PANEL_HEIGHT, flip ? above : below)}px`,
+    ...(flip ? { bottom: `${vh - rect.top + GAP}px` } : { top: `${rect.bottom + GAP}px` }),
+  };
+}
+
+function open(): void {
+  if (props.disabled || isOpen.value) return;
+  isOpen.value = true;
+  emit('open');
+  void nextTick(updatePosition);
+}
+
+function close(): void {
+  if (!isOpen.value) return;
+  isOpen.value = false;
+  emit('close');
+}
+
+function toggle(): void {
+  if (isOpen.value) close();
+  else open();
+}
+
+function onDocumentPointerDown(e: Event): void {
+  const target = e.target as Node | null;
+  if (!target) return;
+  if (triggerRef.value?.contains(target) || panelRef.value?.contains(target)) return;
+  close();
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape') {
+    close();
+    triggerRef.value?.focus();
+  }
+}
+
+// Listeners live only while the panel is open, so a page full of filter chips does
+// not keep N document listeners alive for nothing. Scroll is captured so that
+// scrolling any ancestor container repositions the panel, not just the window.
+function attachListeners(): void {
+  document.addEventListener('pointerdown', onDocumentPointerDown, true);
+  document.addEventListener('keydown', onKeydown);
+  window.addEventListener('scroll', updatePosition, true);
+  window.addEventListener('resize', updatePosition);
+}
+
+function detachListeners(): void {
+  document.removeEventListener('pointerdown', onDocumentPointerDown, true);
+  document.removeEventListener('keydown', onKeydown);
+  window.removeEventListener('scroll', updatePosition, true);
+  window.removeEventListener('resize', updatePosition);
+}
+
+watch(isOpen, (nowOpen) => (nowOpen ? attachListeners() : detachListeners()));
+
+watch(
+  () => props.disabled,
+  (disabled) => {
+    if (disabled) close();
+  },
+);
+
+// Detach directly rather than relying on the watcher: watchers flush async, so an
+// unmount while open would leave the document listeners behind.
+onBeforeUnmount(detachListeners);
+
+defineExpose({ open, close, toggle, isOpen });
+</script>
+
+<template>
+  <div class="sky-filter-dropdown">
+    <button
+      ref="triggerRef"
+      type="button"
+      class="sky-filter-dropdown__trigger"
+      :class="{ 'is-open': isOpen, 'is-disabled': disabled }"
+      :disabled="disabled"
+      aria-haspopup="dialog"
+      :aria-expanded="isOpen"
+      @click="toggle"
+    >
+      <span class="sky-filter-dropdown__title">{{ label }}</span>
+      <span v-if="hasBadge" class="sky-filter-dropdown__badge">{{ badge }}</span>
+      <svg
+        class="sky-filter-dropdown__caret"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+    </button>
+
+    <teleport to="body">
+      <transition name="sky-filter-dropdown-fade">
+        <div
+          v-if="isOpen"
+          ref="panelRef"
+          class="sky-filter-dropdown__panel"
+          role="dialog"
+          :aria-label="title"
+          :style="panelStyle"
+        >
+          <slot :close="close" />
+        </div>
+      </transition>
+    </teleport>
+  </div>
+</template>
+
+<style scoped>
+.sky-filter-dropdown {
+  display: inline-block;
+}
+
+.sky-filter-dropdown__trigger {
+  display: flex;
+  align-items: center;
+  height: var(--sky-filter-trigger-height, 38px);
+  padding: var(--sky-filter-trigger-padding, 0 10px);
+  border: 1px solid var(--sky-filter-trigger-border-color, #ced4da);
+  border-radius: var(--sky-filter-trigger-radius, 5px);
+  background: var(--sky-filter-trigger-bg, transparent);
+  color: var(--sky-filter-trigger-color, inherit);
+  font: inherit;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.sky-filter-dropdown__trigger:focus-visible {
+  outline: 2px solid var(--sky-filter-accent, #106090);
+  outline-offset: 1px;
+}
+
+.sky-filter-dropdown__title {
+  font-size: var(--sky-filter-trigger-font-size, 12pt);
+  font-weight: var(--sky-filter-trigger-font-weight, 500);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sky-filter-dropdown__badge {
+  margin-left: 4px;
+  font-size: 12px;
+  color: var(--sky-filter-badge-color, gray);
+}
+
+.sky-filter-dropdown__caret {
+  flex-shrink: 0;
+  margin-left: 4px;
+  transition: transform 0.2s ease-in-out;
+}
+
+.sky-filter-dropdown__trigger.is-open,
+.sky-filter-dropdown__trigger.is-disabled {
+  color: var(--sky-filter-trigger-muted-color, #b4b4b4);
+}
+
+.sky-filter-dropdown__trigger.is-open .sky-filter-dropdown__caret {
+  transform: rotate(180deg);
+}
+
+.sky-filter-dropdown__trigger.is-disabled {
+  cursor: default;
+}
+
+.sky-filter-dropdown__trigger.is-disabled .sky-filter-dropdown__caret {
+  opacity: 0.5;
+}
+
+/* Panel — teleported to <body>, so an ancestor with transform/filter cannot
+   break the fixed positioning. */
+.sky-filter-dropdown__panel {
+  position: fixed;
+  z-index: var(--sky-filter-panel-z-index, 1000);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  padding: var(--sky-filter-panel-padding, 10px 15px);
+  border-radius: var(--sky-filter-panel-radius, 5px);
+  background: var(--sky-filter-panel-bg, #fff);
+  box-shadow: var(--sky-filter-panel-shadow, 0 5px 8px rgba(0, 0, 0, 0.3));
+}
+
+.sky-filter-dropdown-fade-enter-active {
+  animation: sky-filter-dropdown-in 0.2s;
+}
+
+.sky-filter-dropdown-fade-leave-active {
+  animation: sky-filter-dropdown-in 0.2s reverse;
+}
+
+@keyframes sky-filter-dropdown-in {
+  0% {
+    transform: translate3d(0, -10px, 0);
+    opacity: 0;
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+}
+</style>

--- a/src/shared/ui/SkyFilterDropdown/index.ts
+++ b/src/shared/ui/SkyFilterDropdown/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SkyFilterDropdown.vue';

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -13,6 +13,7 @@ export { default as SkyCardHeader } from './SkyCardHeader';
 export { default as SkyCardRow } from './SkyCardRow';
 export { default as SkyCheckbox } from './SkyCheckbox';
 export { default as SkyDateRangePicker } from './SkyDateRangePicker';
+export { default as SkyFilterDropdown } from './SkyFilterDropdown';
 export { default as SkyInput } from './SkyInput';
 export { default as SkyLoader } from './SkyLoader';
 export { default as SkySelect } from './SkySelect';


### PR DESCRIPTION
## Що тут

**`SkyFilterDropdown`** (shared/ui) — оболонка фільтра: тригер-чіп + панель. Бере на себе тільки спільне (стан відкриття, позиціювання, закриття, доступність), вміст — за викликачем.

**`SkySelectFilter`** (features) — одиничний вибір на цій оболонці, для фільтрів, де бекенд приймає рівно одне значення. Підтримує рядок «без фільтра», пошук і `depth` для відступу дерева.

**`SkyCheckboxFilter`** переведений на оболонку. **Публічний API не змінився** — пропси, події й візуал ті самі.

## Що полагоджено в SkyCheckboxFilter

| Було | Стало |
|---|---|
| Позиція панелі рахувалась один раз при відкритті → «відклеювалась» на скролі, що лікували локом скролу всієї сторінки | Перепозиціювання на scroll (capture) + resize; лок скролу прибраний |
| `document.querySelector` в outside-click → на двох фільтрах влучало не в ту панель | Порівняння через рефи |
| Тригер — `div` з `@click`: ні клавіатури, ні aria | `<button>` + `aria-haspopup`/`aria-expanded`, Esc закриває й повертає фокус |
| `position: fixed` без телепорту — ламався від `transform` у предка | `<teleport to="body">` |
| Слухачі `document` на кожному інстансі з `onMounted` | Лише поки відкрито + явний detach на unmount (watcher'и флашаться асинхронно) |
| Панель без клампу до екрана, список жорстко 250px | Клампиться до країв, розкривається вгору коли знизу тісно, скролиться список |
| Хардкод `#106090` / `#ced4da` / `white` | `--sky-filter-*` зі старими значеннями як fallback |
| Інлайн-стилі, протеклі класи адмінки (`selectColumn`, `filtersCurtain__innerWrap_middle`) | Нормальні scoped-класи, кнопки замість `span @click` |

## Перевірено

`typecheck`, `build`, `docs:build` — зелені. У браузері (headless) на демо-сторінці доків: мульти-вибір, пошук, Esc, клік поза межами, disabled; `document.body.style.overflow` більше не чіпається, панель у `<body>`.

## Лишилось поза цим PR

- Дефолтні лейбли захардкожені українською — `src/langs` у кіті лише passthrough на `window.lang`, класти нікуди; потрібне окреме рішення.
- Немає навігації стрілками по списку опцій (roving tabindex) — реальна дірка a11y.
- `SkyCheckbox` має власний хардкод `#28a745` без CSS-змінних.

## Доки

Сторінки `sky-filter-dropdown` і `sky-select-filter`, демо, картка в галереї, пункти сайдбару, секції README — за чек-лістом з `CLAUDE.md`. У `sky-checkbox-filter` прибрано згадку про лок скролу як про фічу.