### PR TITLE
fix(filters): drop the chip border, match the admin panel 1:1 (2.14.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,10 +1131,11 @@ const range = reactive({ start: '', end: '' }) // { start, end } у формат
 | `title` | `String` | — | Заголовок фільтра (показується у тригері) |
 | `options` | `Array<{ value, name }>` | `[]` | Опції для вибору |
 | `modelValue` | `Array<String\|Number>` | `[]` | Вибрані значення (v-model) |
-| `selectAllLabel` | `String` | `'Вибрати всі'` | Лейбл кнопки "Вибрати всі" |
+| `selectAllLabel` | `String` | `'Обрати все'` | Лейбл кнопки "Обрати все" |
 | `clearLabel` | `String` | `'Очистити'` | Лейбл кнопки "Очистити" |
 | `doneLabel` | `String` | `'Готово'` | Лейбл кнопки "Готово" |
 | `searchPlaceholder` | `String` | `'Пошук'` | Placeholder пошуку |
+| `selectAll` | `Boolean` | `true` | Показувати «Обрати все» |
 | `disabled` | `Boolean` | `false` | Вимкнений стан |
 
 ### SkySelectFilter

--- a/docs/components/sky-checkbox-filter.md
+++ b/docs/components/sky-checkbox-filter.md
@@ -42,10 +42,11 @@ const categoryOptions = [
 | `title` | `String` | — | Заголовок фільтра (показується у тригері) |
 | `options` | `Array<{ value, name }>` | `[]` | Опції для вибору |
 | `modelValue` | `Array<String \| Number>` | `[]` | Вибрані значення (v-model) |
-| `selectAllLabel` | `String` | `'Вибрати всі'` | Лейбл кнопки «Вибрати всі» |
+| `selectAllLabel` | `String` | `'Обрати все'` | Лейбл кнопки «Вибрати всі» |
 | `clearLabel` | `String` | `'Очистити'` | Лейбл кнопки «Очистити» |
 | `doneLabel` | `String` | `'Готово'` | Лейбл кнопки «Готово» |
 | `searchPlaceholder` | `String` | `'Пошук'` | Placeholder пошуку |
+| `selectAll` | `Boolean` | `true` | Показувати «Обрати все». Вимикай, коли споживач приймає лише одне значення |
 | `disabled` | `Boolean` | `false` | Вимкнений стан |
 
 ## Формат опцій

--- a/docs/components/sky-filter-dropdown.md
+++ b/docs/components/sky-filter-dropdown.md
@@ -12,6 +12,7 @@
 - **Закриття:** клік поза межами, `Esc` (фокус повертається на тригер), `disabled` на льоту.
 - **Доступність:** тригер — справжній `<button>` з `aria-haspopup` та `aria-expanded`, панель — `role="dialog"` з `aria-label`.
 - **Слухачі живуть лише поки панель відкрита** — сторінка з десятком фільтрів не тримає десяток слухачів `document`.
+- **Чіп без рамки** — так фільтри виглядають в адмінці. Рамку малює тільки `:focus-visible`; якщо вона таки потрібна, задай `--sky-filter-trigger-border`.
 
 ## Приклад
 
@@ -64,7 +65,7 @@ import { SkyFilterDropdown } from '@skyservice-developers/vue-dev-kit'
 |--------|------------------|------|
 | `--sky-filter-trigger-height` | `38px` | Висота чіпа |
 | `--sky-filter-trigger-padding` | `0 10px` | Падінги чіпа |
-| `--sky-filter-trigger-border-color` | `#ced4da` | Бордер чіпа |
+| `--sky-filter-trigger-border` | `none` | Рамка чіпа. У системному дизайні її немає — задавай лише свідомо |
 | `--sky-filter-trigger-radius` | `5px` | Радіус чіпа |
 | `--sky-filter-trigger-bg` | `transparent` | Фон чіпа |
 | `--sky-filter-trigger-color` | `inherit` | Колір тексту чіпа |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
+++ b/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
@@ -20,11 +20,14 @@ const props = withDefaults(
     clearLabel?: string;
     doneLabel?: string;
     searchPlaceholder?: string;
+    /** Сховати «Обрати все» — коли споживач не може прийняти більше одного значення. */
+    selectAll?: boolean;
     disabled?: boolean;
   }>(),
   {
     modelValue: () => [],
-    selectAllLabel: 'Вибрати всі',
+    selectAll: true,
+    selectAllLabel: 'Обрати все',
     clearLabel: 'Очистити',
     doneLabel: 'Готово',
     searchPlaceholder: 'Пошук',
@@ -60,7 +63,7 @@ const oneSelectedLabel = computed(() => {
 const triggerSummary = computed(() => oneSelectedLabel.value);
 const triggerBadge = computed(() => (selected.value.length > 1 ? selected.value.length : ''));
 
-function selectAll(): void {
+function selectAllOptions(): void {
   selected.value = props.options.map((o) => o.value);
 }
 
@@ -81,7 +84,7 @@ function clearAll(): void {
   >
     <template #default="{ close }">
       <div class="sky-checkbox-filter__actions">
-        <button type="button" class="sky-checkbox-filter__link" @click="selectAll">
+        <button v-if="selectAll" type="button" class="sky-checkbox-filter__link" @click="selectAllOptions">
           {{ selectAllLabel }}
         </button>
         <button type="button" class="sky-checkbox-filter__link" @click="clearAll">
@@ -108,12 +111,21 @@ function clearAll(): void {
 </template>
 
 <style scoped>
+/* Метрики зняті з адмінки (Bootstrap 4.6 .custom-control + правила
+   headerFiltersNew/Dashboard) і відтворені 1:1:
+   .dialog-buttons  → 16px / 500 / #106090, знизу 10px у шапці, зверху 10px у футері
+   .dialogHF        → padding-left: 3px
+   рядок            → бокс 16px зі зсувом 4px, текст із 24px, крок між рядками 34.98px
+   label            → 10pt / line-height 20px / padding-top 2px */
 .sky-checkbox-filter__actions {
   display: flex;
   flex-shrink: 0;
   justify-content: space-between;
-  padding: 8px 0;
-  font-size: 13px;
+  gap: 12px;
+  padding: 0 0 10px;
+  font-size: var(--sky-filter-action-font-size, 1rem);
+  font-weight: var(--sky-filter-action-font-weight, 500);
+  white-space: nowrap;
 }
 
 .sky-checkbox-filter__actions--footer {
@@ -133,20 +145,31 @@ function clearAll(): void {
   text-decoration: underline;
 }
 
-/* The panel caps its own height, so the option list is what scrolls inside it. */
+/* Панель сама обмежує висоту, тож скролиться список, а не сторінка. */
 .sky-checkbox-filter__options {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  padding-left: 3px;
 }
 
 .sky-checkbox-filter__option {
-  padding: 0 4px;
-  margin-bottom: 5px;
+  /* flex, а не block: інлайновий SkyCheckbox інакше тягне за собою strut
+     від line-height хоста, і крок рядків їде. */
+  display: flex;
+  --sky-checkbox-font-size: 10pt;
+  --sky-checkbox-line-height: 20px;
+  --sky-checkbox-align: flex-start;
+  --sky-checkbox-box-offset: 4px;
+  --sky-checkbox-label-margin: 0;
+  --sky-checkbox-label-offset: 2px;
+  margin-bottom: 13px;
 }
 
 .sky-checkbox-filter__sep {
   flex-shrink: 0;
   margin: 0 0 2px;
+  border: 0;
+  border-top: 1px solid var(--sky-filter-separator-color, rgba(0, 0, 0, 0.1));
 }
 </style>

--- a/src/shared/ui/SkyCheckbox/SkyCheckbox.vue
+++ b/src/shared/ui/SkyCheckbox/SkyCheckbox.vue
@@ -75,14 +75,14 @@ const isChecked = () => {
 <style scoped>
 .sky-checkbox {
   display: inline-flex;
-  align-items: center;
-  gap: 8px;
+  align-items: var(--sky-checkbox-align, center);
+  gap: var(--sky-checkbox-gap, 8px);
   cursor: pointer;
   user-select: none;
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: var(--sky-checkbox-font-size, 14px);
+  line-height: var(--sky-checkbox-line-height, 1.5);
   font-weight: 400;
-  color: #212529;
+  color: var(--sky-checkbox-color, #212529);
   margin-bottom: 0;
 }
 
@@ -103,10 +103,11 @@ const isChecked = () => {
 /* ── Classic checkbox ── */
 .sky-checkbox__box {
   flex-shrink: 0;
-  width: 16px;
-  height: 16px;
-  border-radius: 4px;
-  border: 1px solid #adb5bd;
+  width: var(--sky-checkbox-size, 16px);
+  height: var(--sky-checkbox-size, 16px);
+  margin-top: var(--sky-checkbox-box-offset, 0);
+  border-radius: var(--sky-checkbox-radius, 4px);
+  border: 1px solid var(--sky-checkbox-border-color, #adb5bd);
   background: #fff;
   display: flex;
   align-items: center;
@@ -124,8 +125,8 @@ const isChecked = () => {
 }
 
 .sky-checkbox__input:checked ~ .sky-checkbox__box {
-  background-color: #28a745;
-  border-color: #28a745;
+  background-color: var(--sky-checkbox-accent, #28a745);
+  border-color: var(--sky-checkbox-accent, #28a745);
 }
 
 .sky-checkbox__input:checked ~ .sky-checkbox__box .sky-checkbox__check {
@@ -135,12 +136,12 @@ const isChecked = () => {
 .sky-checkbox:not(.sky-checkbox--disabled):hover
   .sky-checkbox__input:not(:checked)
   ~ .sky-checkbox__box {
-  border-color: #28a745;
+  border-color: var(--sky-checkbox-accent, #28a745);
 }
 
 .sky-checkbox__input:focus ~ .sky-checkbox__box {
   box-shadow: 0 0 0 0.25rem rgba(40, 167, 69, 0.25);
-  border-color: #28a745;
+  border-color: var(--sky-checkbox-accent, #28a745);
 }
 
 /* ── Switch ── */
@@ -185,7 +186,8 @@ const isChecked = () => {
 
 /* ── Label ── */
 .sky-checkbox__label {
-  margin-left: 4px;
+  margin-left: var(--sky-checkbox-label-margin, 4px);
+  padding-top: var(--sky-checkbox-label-offset, 0);
   flex: 1;
   min-width: 0;
 }

--- a/src/shared/ui/SkyFilterDropdown/FilterSearch.vue
+++ b/src/shared/ui/SkyFilterDropdown/FilterSearch.vue
@@ -57,6 +57,9 @@ const emit = defineEmits<{
   width: 100%;
   margin: 0;
   padding: 4px 24px 4px 0;
+  /* Прибитий явно: успадкований від хоста line-height роздував рядок пошуку
+     (в адмінці він рівно 28px). */
+  line-height: 1.5;
   border: none;
   outline: none;
   background: transparent;

--- a/src/shared/ui/SkyFilterDropdown/SkyFilterDropdown.vue
+++ b/src/shared/ui/SkyFilterDropdown/SkyFilterDropdown.vue
@@ -197,7 +197,9 @@ defineExpose({ open, close, toggle, isOpen });
   align-items: center;
   height: var(--sky-filter-trigger-height, 38px);
   padding: var(--sky-filter-trigger-padding, 0 10px);
-  border: 1px solid var(--sky-filter-trigger-border-color, #ced4da);
+  /* Фільтр-чіпи в системному дизайні без рамки — її малює лише :focus-visible.
+     Радіус лишається на випадок, коли споживач задає бордер або фон. */
+  border: var(--sky-filter-trigger-border, none);
   border-radius: var(--sky-filter-trigger-radius, 5px);
   background: var(--sky-filter-trigger-bg, transparent);
   color: var(--sky-filter-trigger-color, inherit);


### PR DESCRIPTION
## Головне: рамки на чіпі бути не має

В адмінці правило таке:

```css
.header-filter-block {
  border: none !important;   /* виграє */
  ...
  border: 1px solid #ced4da; /* ніколи не застосовується */
}
```

`!important` б'є пізнішу декларацію в тому ж блоці, тож чіпи фільтрів **безбордерні**. Той самий мертвий рядок лежав і в старому `SkyCheckboxFilter`. У 2.14.0 я прибирав це протиріччя і лишив не ту декларацію — намалював рамку, якої в системному дизайні немає.

Тепер `border: var(--sky-filter-trigger-border, none)`. Повернути рамку можна, але тільки свідомо.

## Решта метрик зведена з еталоном

Еталон зібрано з Bootstrap 4.6 `.custom-control` + правил `headerFiltersNew.vue` / `Dashboard.vue` і зміряно в браузері. Порівняння після фіксу:

| Метрика | Адмінка | Кіт |
|---|---|---|
| `.dialog-buttons` font-size / weight / color | 16px / 500 / #106090 | те саме |
| padding шапки / футера | `0 0 10px` / `10px 0 0` | те саме |
| висота рядка пошуку | 28px | 28px |
| `padding-left` списку | 3px | 3px |
| крок рядків | 34.98px | 35px |
| зсув тексту від краю | 24px | 24px |
| лейбл font-size / line-height | 10pt / 20px | те саме |
| зсув боксу чекбокса | 4px | 4px |
| `hr` | 1px rgba(0,0,0,.1) | те саме |

Два місця, де числа розʼїжджалися, — успадкований від хоста `line-height`: він роздував рядок пошуку і крок рядків. Прибитий явно.

Метрики `SkyCheckbox` винесені в `--sky-checkbox-*` (значення ті самі), інакше підігнати рядок під Bootstrap-геометрію можна було б лише через `:deep()`.

Дефолт `selectAllLabel` → «Обрати все», як в адмінці.

## Новий проп

`selectAll` (default `true`) — ховає «Обрати все» для споживачів, які приймають рівно одне значення.