### PR TITLE
fix(SkyCheckboxFilter): clickable option row (2.14.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
+++ b/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
@@ -166,6 +166,14 @@ function clearAll(): void {
   margin-bottom: 13px;
 }
 
+/* Єдине свідоме відхилення від адмінки, і воно невидиме: там лейбл завширшки з
+   текст, тож клік праворуч від напису нікуди не потрапляє. Розтягуємо його на
+   весь рядок — позиція тексту та сама, ціль для кліка нормальна. */
+.sky-checkbox-filter__option :deep(.sky-checkbox) {
+  flex: 1;
+  min-width: 0;
+}
+
 .sky-checkbox-filter__sep {
   flex-shrink: 0;
   margin: 0 0 2px;


### PR DESCRIPTION
В адмінці лейбл чекбокса завширшки з текст, тож клік праворуч від напису не потрапляє нікуди. Розтягуємо лейбл на весь рядок — позиція тексту та сама, метрики не зсунулись (перевірено виміром), ціль для кліка нормальна.

Єдине свідоме відхилення від адмінки, і воно невидиме.