### PR TITLE
fix(SkyCheckboxFilter): centre the label against the checkbox (2.14.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyservice-developers/vue-dev-kit",
-      "version": "2.14.3",
+      "version": "2.14.4",
       "license": "MIT",
       "dependencies": {
         "@tanstack/vue-table": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
+++ b/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
@@ -164,14 +164,13 @@ function clearAll(): void {
   --sky-checkbox-gap: 4px;
   --sky-checkbox-font-size: 10pt;
   --sky-checkbox-line-height: 20px;
-  --sky-checkbox-align: flex-start;
-  --sky-checkbox-box-offset: 4px;
   --sky-checkbox-label-margin: 0;
-  --sky-checkbox-label-offset: 2px;
-  /* Крок рядків 35px, як в адмінці (34.98). Там бокс абсолютно спозиційований і у
-     висоту рядка не входить, у нас він флексовий і робить рядок 24px (20 + 4 зсув),
-     тож лишок — 11, а не 13. Візуально збігається до пікселя. */
-  margin-bottom: 11px;
+  /* Текст центрується по боксу, а не як в адмінці. Там Bootstrap ставить ::before на
+     top: 4px під розмір 16px, а Dashboard.vue роздуває бокс до 20px, не чіпаючи top —
+     через це текст виявляється на 3px вище центру. Це баг, а не рішення, тож не
+     копіюємо: у нас обидва по 20px і align-items: center дає рівно 0.
+     Крок рядків лишається 35px (рядок 20 + 15). */
+  margin-bottom: 15px;
 }
 
 /* Єдине свідоме відхилення від адмінки, і воно невидиме: там лейбл завширшки з


### PR DESCRIPTION
Текст стояв на 2px вище центру бокса.

В адмінці те саме, тільки гірше — на **3px**: Bootstrap ставить `.custom-control-label::before` на `top: 4px` під розмір 16px, а `Dashboard.vue` глобально роздуває бокс до 20px, `top` не чіпаючи. Це баг верстки, а не рішення, тож не копіюємо.

| | зсув glyph-центру від центру бокса |
|---|---|
| адмінка | −3px |
| кіт до | −2px |
| кіт після | **0** |

Крок рядків лишається 35px (рядок 20px замість 24 → `margin-bottom: 15` замість 11). Решта метрик — бокс 20px, зазор 4px, текст із 24px, шрифт 10pt, пошук 28px, `padding-left: 3px` — не зсунулась, перевірено виміром.