### PR TITLE
fix(SkyCheckbox): honour the contract of the checkbox it replaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,9 +570,14 @@ import {
 | Prop | Тип | За замовчуванням | Опис |
 |------|-----|------------------|------|
 | `modelValue` | `Boolean\|Array` | — | Стан/масив вибраних значень (v-model) |
-| `value` | `String\|Number` | — | Значення для array-режиму |
+| `value` | `String\|Number` | — | Значення для array-режиму (**обов'язкове** в ньому) |
 | `switch` | `Boolean` | `false` | Режим switch замість чекбоксу |
 | `disabled` | `Boolean` | `false` | Вимкнений стан |
+| `indeterminate` | `Boolean` | `false` | Третій стан — «обрано частину»; малює риску, на `checked` не впливає |
+
+Атрибути, які не `class`/`style`, їдуть на сам `<input>` — `name`, `required`,
+`tabindex`, `aria-*` стосуються контрола. `class` і `style` лишаються на корені,
+бо ними позиціонують обгортку.
 
 #### Slots
 

--- a/docs/.vitepress/theme/demos/SkyCheckboxDemo.vue
+++ b/docs/.vitepress/theme/demos/SkyCheckboxDemo.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue'
+import { computed } from 'vue'
 import SkyCheckbox from '@/shared/ui/SkyCheckbox/SkyCheckbox.vue'
 
 const agreed = ref(true)
@@ -10,6 +11,12 @@ const options = [
   { value: 'b', name: 'Їжа' },
   { value: 'c', name: 'Напої' },
 ]
+
+const allSelected = computed(() => selected.value.length === options.length)
+const someSelected = computed(() => selected.value.length > 0)
+function toggleAll() {
+  selected.value = allSelected.value ? [] : options.map((o) => o.value)
+}
 </script>
 
 <template>
@@ -23,6 +30,18 @@ const options = [
       {{ opt.name }}
     </SkyCheckbox>
     <span class="vdk-demo-out">selected: [{{ selected.join(', ') }}]</span>
+  </Demo>
+
+  <Demo title="Третій стан — «обрано частину»" column>
+    <SkyCheckbox :model-value="allSelected" :indeterminate="someSelected && !allSelected" @update:model-value="toggleAll">
+      Обрати всі
+    </SkyCheckbox>
+    <SkyCheckbox v-for="opt in options" :key="opt.value" v-model="selected" :value="opt.value">
+      {{ opt.name }}
+    </SkyCheckbox>
+    <span class="vdk-demo-out">
+      обрано {{ selected.length }} з {{ options.length }} — головний чекбокс з рискою, поки не всі
+    </span>
   </Demo>
 
   <Demo title="Switch + disabled" column>

--- a/docs/components/sky-checkbox.md
+++ b/docs/components/sky-checkbox.md
@@ -51,9 +51,37 @@ const options = [
 | Prop | Тип | За замовчуванням | Опис |
 |------|-----|------------------|------|
 | `modelValue` | `Boolean \| Array` | — | Стан / масив вибраних значень (v-model) |
-| `value` | `String \| Number` | — | Значення для array-режиму |
+| `value` | `String \| Number` | — | Значення для array-режиму (**обов'язкове** в ньому) |
 | `switch` | `Boolean` | `false` | Режим switch замість чекбоксу |
 | `disabled` | `Boolean` | `false` | Вимкнений стан |
+| `indeterminate` | `Boolean` | `false` | Третій стан — «обрано частину» |
+
+## Атрибути
+
+Усе, що не `class` і не `style`, потрапляє на сам `<input>`: `name`, `required`,
+`tabindex`, `autofocus`, `aria-*` стосуються контрола, і на `<label>` вони нічого
+не роблять. `class` і `style` лишаються на корені — ними позиціонують обгортку.
+
+```vue
+<SkyCheckbox v-model="agreed" name="agree" required class="mt-2">Погоджуюсь</SkyCheckbox>
+<!-- name і required → на <input>, mt-2 → на <label> -->
+```
+
+## Третій стан
+
+`indeterminate` — це «обрано частину», класичний головний чекбокс над списком.
+Як і в DOM, він **не** пов'язаний з `checked`: прапорець лишається таким, яким ви
+його задали, змінюється лише вигляд.
+
+```vue
+<SkyCheckbox
+  :model-value="allSelected"
+  :indeterminate="someSelected && !allSelected"
+  @update:model-value="toggleAll"
+>
+  Обрати всі
+</SkyCheckbox>
+```
 
 ## Slots
 
@@ -81,6 +109,12 @@ const options = [
 <SkyCheckbox v-model="selected" value="b">B</SkyCheckbox>
 <!-- selected: ['a'], ['a','b'], [] ... -->
 ```
+
+::: warning `value` тут обов'язковий
+У режимі масиву без `value` класти в список нема чого — компонент пропускає зміну
+й пише попередження в консоль (у dev). Масив, який ви передали, не мутується:
+завжди приходить новий.
+:::
 
 ## Switch
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/shared/ui/SkyCheckbox/SkyCheckbox.test.ts
+++ b/src/shared/ui/SkyCheckbox/SkyCheckbox.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import SkyCheckbox from './SkyCheckbox.vue';
+
+/**
+ * Кожен блок нижче — одна з обіцянок нативного `<input type="checkbox">`, яку
+ * компонент має тримати, щоб його можна було ставити на місце нативного, не
+ * перевіряючи щоразу, чи він поводиться так само (Liskov Substitution).
+ */
+
+/** Кліком не обійтись: треба саме розсинхрон DOM і пропів, як після відхиленого оновлення. */
+async function fireChange(wrapper: ReturnType<typeof mount>, checked: boolean) {
+  const input = wrapper.get('input');
+  (input.element as HTMLInputElement).checked = checked;
+  await input.trigger('change');
+}
+
+describe('SkyCheckbox — режим boolean', () => {
+  it('віддає новий стан', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: false } });
+    await fireChange(wrapper, true);
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([true]);
+  });
+
+  it('малює галочку за modelValue', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: true } });
+    expect((wrapper.get('input').element as HTMLInputElement).checked).toBe(true);
+
+    await wrapper.setProps({ modelValue: false });
+    expect((wrapper.get('input').element as HTMLInputElement).checked).toBe(false);
+  });
+});
+
+describe('SkyCheckbox — режим масиву', () => {
+  it('додає значення при виборі', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: ['a'], value: 'b' } });
+    await fireChange(wrapper, true);
+
+    expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual(['a', 'b']);
+  });
+
+  it('прибирає значення при знятті', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: ['a', 'b'], value: 'b' } });
+    await fireChange(wrapper, false);
+
+    expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual(['a']);
+  });
+
+  // Найважливіший тест файлу. splice(indexOf(v), 1) при indexOf === -1 зрізав
+  // ОСТАННІЙ елемент: чекбокс, у якого просили зняти 'c', видаляв 'b'.
+  it('не чіпає чужі елементи, коли свого значення в списку немає', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: ['a', 'b'], value: 'c' } });
+    await fireChange(wrapper, false);
+
+    expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual(['a', 'b']);
+  });
+
+  it('не дублює значення, якщо воно вже у списку', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: ['a'], value: 'a' } });
+    await fireChange(wrapper, true);
+
+    expect(wrapper.emitted('update:modelValue')?.[0][0]).toEqual(['a']);
+  });
+
+  it('не пхає undefined у список, коли `value` не задали', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: ['a'] } });
+    await fireChange(wrapper, true);
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+    warn.mockRestore();
+  });
+
+  it('не мутує масив, який дав споживач', async () => {
+    const source = ['a', 'b'];
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: source, value: 'b' } });
+    await fireChange(wrapper, false);
+
+    expect(source).toEqual(['a', 'b']);
+  });
+});
+
+describe('SkyCheckbox — третій стан', () => {
+  it('вмикає indeterminate на самому інпуті', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: false, indeterminate: true } });
+
+    expect((wrapper.get('input').element as HTMLInputElement).indeterminate).toBe(true);
+  });
+
+  it('знімає indeterminate разом із пропом', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: false, indeterminate: true } });
+    await wrapper.setProps({ indeterminate: false });
+
+    expect((wrapper.get('input').element as HTMLInputElement).indeterminate).toBe(false);
+  });
+
+  it('лишається окремим від checked, як у DOM', () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: true, indeterminate: true } });
+    const input = wrapper.get('input').element as HTMLInputElement;
+
+    expect(input.checked).toBe(true);
+    expect(input.indeterminate).toBe(true);
+  });
+});
+
+describe('SkyCheckbox — атрибути', () => {
+  it('віддає атрибути контрола самому <input>', () => {
+    const wrapper = mount(SkyCheckbox, {
+      props: { modelValue: false },
+      attrs: { name: 'agree', required: true, tabindex: '-1', 'aria-label': 'Погоджуюсь' },
+    });
+    const input = wrapper.get('input');
+
+    expect(input.attributes('name')).toBe('agree');
+    expect(input.attributes('required')).toBeDefined();
+    expect(input.attributes('tabindex')).toBe('-1');
+    expect(input.attributes('aria-label')).toBe('Погоджуюсь');
+  });
+
+  // Без inheritAttrs: false вони осідали б ще й на <label>, де нічого не значать:
+  // name/required не потрапляли б у форму, а tabindex зробив би фокусованою
+  // обгортку замість контрола.
+  it('не лишає їх на <label>', () => {
+    const wrapper = mount(SkyCheckbox, {
+      props: { modelValue: false },
+      attrs: { name: 'agree', required: true, tabindex: '-1' },
+    });
+
+    expect(wrapper.attributes('name')).toBeUndefined();
+    expect(wrapper.attributes('required')).toBeUndefined();
+    expect(wrapper.attributes('tabindex')).toBeUndefined();
+  });
+
+  it('лишає class і style на корені — ними позиціонують обгортку', () => {
+    const wrapper = mount(SkyCheckbox, {
+      props: { modelValue: false },
+      attrs: { class: 'my-box', style: 'margin-top: 4px' },
+    });
+
+    expect(wrapper.classes()).toContain('my-box');
+    expect(wrapper.classes()).toContain('sky-checkbox');
+    expect(wrapper.attributes('style')).toContain('margin-top');
+    expect(wrapper.get('input').classes()).not.toContain('my-box');
+  });
+});
+
+describe('SkyCheckbox — реактивність пропів', () => {
+  it('перемикається в switch і назад після зміни пропа', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: false, switch: false } });
+    expect(wrapper.find('.sky-checkbox__track').exists()).toBe(false);
+
+    await wrapper.setProps({ switch: true });
+    expect(wrapper.find('.sky-checkbox__track').exists()).toBe(true);
+
+    await wrapper.setProps({ switch: false });
+    expect(wrapper.find('.sky-checkbox__box').exists()).toBe(true);
+  });
+
+  it('реагує на зміну disabled', async () => {
+    const wrapper = mount(SkyCheckbox, { props: { modelValue: false } });
+    expect(wrapper.get('input').attributes('disabled')).toBeUndefined();
+
+    await wrapper.setProps({ disabled: true });
+    expect(wrapper.get('input').attributes('disabled')).toBeDefined();
+    expect(wrapper.classes()).toContain('sky-checkbox--disabled');
+  });
+});

--- a/src/shared/ui/SkyCheckbox/SkyCheckbox.vue
+++ b/src/shared/ui/SkyCheckbox/SkyCheckbox.vue
@@ -1,39 +1,80 @@
 <script setup lang="ts">
+import { computed, useAttrs } from "vue";
+
 const props = defineProps<{
   modelValue: boolean | (string | number)[];
+  /** Обов'язковий, коли `modelValue` — масив: саме він кладеться/знімається. */
   value?: string | number;
   switch?: boolean;
   disabled?: boolean;
+  /**
+   * Третій стан нативного чекбокса — «обрано частину». Візуально це риска
+   * замість галочки; на `checked` не впливає, як і в DOM.
+   */
+  indeterminate?: boolean;
 }>();
 
 const emit = defineEmits<{
   "update:modelValue": [value: boolean | (string | number)[]];
 }>();
 
-const switchMode = props.switch;
+defineOptions({ inheritAttrs: false });
+
+// class/style лишаються на корені (споживачі позиціонують саме обгортку), решта
+// атрибутів їде на <input> — name, required, tabindex, aria-* стосуються контрола,
+// і на <label> вони просто нічого не роблять.
+const attrs = useAttrs();
+const rootAttrs = computed(() => ({ class: attrs.class, style: attrs.style }));
+const inputAttrs = computed(() => {
+  const { class: _class, style: _style, ...rest } = attrs;
+  return rest;
+});
+
+// computed, а не значення з setup: props реактивні за контрактом Vue, тож
+// зчитане один раз перемикання перестало б відповідати пропу після зміни.
+const switchMode = computed(() => props.switch);
+
+const isChecked = computed(() => {
+  if (Array.isArray(props.modelValue)) {
+    return props.modelValue.includes(props.value as string | number);
+  }
+  return props.modelValue;
+});
 
 function handleChange(event: Event) {
   const target = event.target as HTMLInputElement;
-  if (Array.isArray(props.modelValue)) {
-    const arr = [...(props.modelValue as any[])];
-    if (target.checked) arr.push(props.value);
-    else arr.splice(arr.indexOf(props.value), 1);
-    emit("update:modelValue", arr);
-  } else {
-    emit("update:modelValue", target.checked);
-  }
-}
 
-const isChecked = () => {
-  if (Array.isArray(props.modelValue)) {
-    return (props.modelValue as any[]).includes(props.value);
+  if (!Array.isArray(props.modelValue)) {
+    emit("update:modelValue", target.checked);
+    return;
   }
-  return props.modelValue as boolean;
-};
+
+  // Без `value` у режимі масиву класти в список нема чого: раніше туди їхав
+  // undefined і мовчки псував дані споживача.
+  if (props.value === undefined) {
+    console.warn(
+      "[SkyCheckbox] `modelValue` є масивом, але проп `value` не заданий — класти в список " +
+        "нема чого, зміну проігноровано.",
+    );
+    return;
+  }
+
+  const next = [...props.modelValue];
+  if (target.checked) {
+    if (!next.includes(props.value)) next.push(props.value);
+  } else {
+    const at = next.indexOf(props.value);
+    // splice(-1, 1) зрізав би останній елемент — тобто зняття галочки з
+    // відсутнього значення видаляло б чужий, ні до чого не причетний запис.
+    if (at !== -1) next.splice(at, 1);
+  }
+  emit("update:modelValue", next);
+}
 </script>
 
 <template>
   <label
+    v-bind="rootAttrs"
     class="sky-checkbox"
     :class="{
       'sky-checkbox--switch': switchMode,
@@ -41,9 +82,11 @@ const isChecked = () => {
     }"
   >
     <input
+      v-bind="inputAttrs"
       type="checkbox"
       class="sky-checkbox__input"
-      :checked="isChecked()"
+      :checked="isChecked"
+      :indeterminate.prop="indeterminate"
       :disabled="disabled"
       @change="handleChange"
     />
@@ -64,6 +107,7 @@ const isChecked = () => {
           stroke-linejoin="round"
         />
       </svg>
+      <span class="sky-checkbox__dash" />
     </span>
 
     <span v-if="$slots.default" class="sky-checkbox__label">
@@ -102,6 +146,7 @@ const isChecked = () => {
 
 /* ── Classic checkbox ── */
 .sky-checkbox__box {
+  position: relative; /* якір для .sky-checkbox__dash */
   flex-shrink: 0;
   box-sizing: border-box;
   width: var(--sky-checkbox-size, 16px);
@@ -126,9 +171,30 @@ const isChecked = () => {
   transition: opacity 0.1s ease-in-out;
 }
 
-.sky-checkbox__input:checked ~ .sky-checkbox__box {
+/* Риска для третього стану — «обрано частину». */
+.sky-checkbox__dash {
+  position: absolute;
+  width: calc(var(--sky-checkbox-size, 16px) * 0.5);
+  height: 2px;
+  border-radius: 1px;
+  background: #fff;
+  opacity: 0;
+  transition: opacity 0.1s ease-in-out;
+}
+
+.sky-checkbox__input:checked ~ .sky-checkbox__box,
+.sky-checkbox__input:indeterminate ~ .sky-checkbox__box {
   background-color: var(--sky-checkbox-accent, #28a745);
   border-color: var(--sky-checkbox-accent, #28a745);
+}
+
+/* indeterminate б'є checked, як і в DOM: третій стан видно навіть на checked. */
+.sky-checkbox__input:indeterminate ~ .sky-checkbox__box .sky-checkbox__check {
+  opacity: 0;
+}
+
+.sky-checkbox__input:indeterminate ~ .sky-checkbox__box .sky-checkbox__dash {
+  opacity: 1;
 }
 
 .sky-checkbox__input:checked ~ .sky-checkbox__box .sky-checkbox__check {


### PR DESCRIPTION
`SkyCheckbox` існує, щоб ставити його там, де стояв би `<input type="checkbox">`. Саме тому кожне місце, де він поводиться не так, як нативний, — це не «дрібна незручність», а зламана обіцянка: споживач не може підставити його, не перевіривши щоразу, чи він поводиться так само.

Це і є **Liskov Substitution** — третя літера в SOLID. Формулювання Барбари Лісков: якщо `S` — підтип `T`, то об'єкти `T` можна замінити на об'єкти `S`, не змінюючи коректності програми. Для UI-компонента «супертип» — це контрол, який він собою заміняє, і його власний оголошений контракт пропів.

Нижче — п'ять місць, де підстановка ламалась. Порядок за шкодою, а не за складністю.

---

## 1. Компонент видаляв чужі дані

```js
else arr.splice(arr.indexOf(props.value), 1);
```

`indexOf` повертає `-1`, коли значення в масиві немає. `splice(-1, 1)` рахує від кінця й зрізає **останній** елемент.

```
props: modelValue ['a','b'], value 'c'  →  зняти галочку  →  emit ['a']
```

У чекбокса попросили прибрати `'c'`. Він видалив `'b'`.

**«Це ж недосяжно?»** Досяжно. `:checked="isChecked()"` — це прив'язка, а не контрольоване значення: DOM живе своїм життям між рендерами. Щойно батько відхиляє або переписує оновлення — наприклад, тримає правило «хоча б один має лишитись обраним» — інпут лишається відмічений, а пропи кажуть протилежне. Наступний клік з'їдає сусіда.

Нативний чекбокс не вміє зіпсувати стан сусіднього. Тому підстановка тут небезпечна не в теорії, а на практиці.

```js
const at = next.indexOf(props.value);
if (at !== -1) next.splice(at, 1);
```

## 2. `switch` не був реактивним

```js
const switchMode = props.switch;   // читається один раз у setup
```

Пропи у Vue реактивні **за контрактом**. Той, хто передає `:switch="isMobile"`, має право очікувати, що вигляд зміниться разом зі значенням. Тут — ні: `setProps({ switch: true })` не робив нічого.

Це та сама LSP, тільки супертип — не нативний інпут, а власний оголошений контракт: однакові пропи давали різний результат залежно від того, **коли** їх встановили.

## 3. Атрибути осідали не на тому елементі

Корінь — `<label>`, `inheritAttrs` лишався ввімкненим. Тож `name`, `required`, `tabindex`, `autofocus`, `aria-*` чіплялись до лейбла, де не значать нічого: у форму такий чекбокс не потрапляв, `required` не валідувався, а `tabindex="-1"` робив нефокусованою обгортку замість контрола.

Найпідступніший різновид порушення: компонент **приймає** все, що приймає супертип, і мовчки не виконує нічого з цього. Помилки немає — просто не працює.

Тепер усе, крім `class` і `style`, іде на `<input>`; `class`/`style` лишаються на корені, бо ними позиціонують обгортку (і щоб не зламати наявних споживачів).

## 4. Не було третього стану

Нативний чекбокс має три стани: обрано, не обрано, `indeterminate` — «обрано частину». Тут було два. Звичайний «Обрати всі» над списком виразити було нічим.

Показово, що кіт уже впирався в це сам: `useTableSelection.ts` віддає прапорець часткового вибору з коментарем *«для indeterminate-стану чекбокса в шапці»* — і жодного чекбокса, здатного його намалювати.

**Звуження простору станів** — теж порушення LSP: підтип має приймати все, що приймає супертип, а не менше. Додано пропом, і, як у DOM, він **не** пов'язаний з `checked`.

## 5. Тип обіцяв більше, ніж компонент виконував

```ts
modelValue: boolean | (string | number)[];
value?: string | number;      // ← «необов'язковий»
```

У режимі масиву `value` насправді обов'язковий: без нього в масив споживача летів `arr.push(undefined)`. Сигнатура дозволяла те, чого реалізація не вміє — **посилена передумова**, не виражена в типі.

Тепер зміна пропускається з попередженням, а вхідний масив ніколи не мутується.

---

## Тести

15 тестів, по одному на кожну обіцянку. Написані як специфікація: «не чіпає чужі елементи, коли свого значення в списку немає» читається як вимога, а не як опис реалізації.

Кожен тест перевірено мутацією — старий код повертався на місце, і тест мав упасти:

| повернув баг | упало |
|---|---|
| `splice` без перевірки на `-1` | 1 |
| `switch` читається один раз | 1 |
| атрибути на `<label>` | 1 |
| прибрати `indeterminate` | 2 |
| пускати `undefined` у масив | 1 |

Перша спроба тесту на атрибути мутацію **не зловила**: він перевіряв, що атрибути доїхали до інпута, але не перевіряв, що вони перестали дублюватись на лейблі. Тест, який не падає на зламаному коді, не тестує нічого — тому мутаційна перевірка тут не формальність.

## Що це означає для споживачів

Ламких змін немає. `class`/`style` лишились на корені, решта пропів на місці, додався `indeterminate`.

Далі цим замінюються саморобні чекбокси у `woocommerce` і `shopify` — там списки товарів малювали нативні інпути з `accent-color`, бо `indeterminate` і `tabindex` через кіт не проходили. Тепер проходять.

## Якщо хочеться копнути

Практична вправа: візьміть будь-який компонент кіта, який заміняє нативний контрол, і спитайте — «що приймає нативний, чого не приймає цей?». `name`, `form`, `readonly`, `autofocus`, `:focus-visible`, події `focus`/`blur`, третій стан. Кожна відповідь — або свідоме рішення, задокументоване, або дірка, як тут.
