### PR TITLE
feat(SkyCheckboxFilter): searchable prop (2.16.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ import {
 | `dropdownTitle` | `String` | `'Останні відвідані розділи'` | Заголовок дропдауну |
 | `visitLabel` | `String` | `'Останнє відвідування'` | Підпис часу в дропдауні |
 | `trackPageName` | `String` | `''` | Назва сторінки для трекінгу відвідувань |
-| `trackPagePath` | `String` | `''` | Шлях сторінки для трекінгу |
+| `trackPagePath` | `String` | `''` | Шлях сторінки для трекінгу (за замовчуванням `/apps/{trackPageName}`; актуальний дашборд підставляє свій реальний маршрут) |
 | `appId` | `String` | `''` | Ідентифікатор додатку для iframe bridge |
 
 #### Slots
@@ -1209,6 +1209,7 @@ const range = reactive({ start: '', end: '' }) // { start, end } у формат
 | `doneLabel` | `String` | `'Готово'` | Лейбл кнопки "Готово" |
 | `searchPlaceholder` | `String` | `'Пошук'` | Placeholder пошуку |
 | `selectAll` | `Boolean` | `true` | Показувати «Обрати все» |
+| `searchable` | `Boolean` | `true` | Показувати поле пошуку |
 | `disabled` | `Boolean` | `false` | Вимкнений стан |
 
 ### SkySelectFilter

--- a/docs/components/header.md
+++ b/docs/components/header.md
@@ -53,7 +53,7 @@ function goTo(item) {
 | `dropdownTitle` | `String` | `'Останні відвідані розділи'` | Заголовок дропдауну |
 | `visitLabel` | `String` | `'Останнє відвідування'` | Підпис часу в дропдауні |
 | `trackPageName` | `String` | `''` | Назва сторінки для трекінгу відвідувань |
-| `trackPagePath` | `String` | `''` | Шлях сторінки для трекінгу |
+| `trackPagePath` | `String` | `''` | Шлях сторінки для трекінгу (за замовчуванням `/apps/{trackPageName}`; актуальний дашборд підставляє свій реальний маршрут) |
 | `appId` | `String` | `''` | Ідентифікатор додатку для iframe bridge |
 
 ### Формат `dropdownItems`

--- a/docs/components/sky-checkbox-filter.md
+++ b/docs/components/sky-checkbox-filter.md
@@ -47,6 +47,7 @@ const categoryOptions = [
 | `doneLabel` | `String` | `'Готово'` | Лейбл кнопки «Готово» |
 | `searchPlaceholder` | `String` | `'Пошук'` | Placeholder пошуку |
 | `selectAll` | `Boolean` | `true` | Показувати «Обрати все». Вимикай, коли споживач приймає лише одне значення |
+| `searchable` | `Boolean` | `true` | Показувати поле пошуку |
 | `disabled` | `Boolean` | `false` | Вимкнений стан |
 
 ## Формат опцій

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyservice-developers/vue-dev-kit",
-      "version": "2.16.0",
+      "version": "2.16.1",
       "license": "MIT",
       "dependencies": {
         "@tanstack/vue-table": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
+++ b/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
@@ -22,11 +22,14 @@ const props = withDefaults(
     searchPlaceholder?: string;
     /** Сховати «Обрати все» — коли споживач не може прийняти більше одного значення. */
     selectAll?: boolean;
+    /** Сховати пошук — для коротких фіксованих списків він лише шумить. */
+    searchable?: boolean;
     disabled?: boolean;
   }>(),
   {
     modelValue: () => [],
     selectAll: true,
+    searchable: true,
     selectAllLabel: 'Обрати все',
     clearLabel: 'Очистити',
     doneLabel: 'Готово',
@@ -92,7 +95,12 @@ function clearAll(): void {
         </button>
       </div>
 
-      <FilterSearch v-model="searchQuery" :placeholder="searchPlaceholder" :label="title" />
+      <FilterSearch
+        v-if="searchable"
+        v-model="searchQuery"
+        :placeholder="searchPlaceholder"
+        :label="title"
+      />
 
       <div class="sky-checkbox-filter__options">
         <div v-for="opt in filteredOptions" :key="opt.value" class="sky-checkbox-filter__option">

--- a/src/shared/ui/Header/Header.vue
+++ b/src/shared/ui/Header/Header.vue
@@ -148,11 +148,14 @@ const isDropdownOpen = ref(false)
 const localStorageItems = ref([])
 const parentLang = ref({})
 
-// Track page visit in parent's componentStats
+// Track page visit in parent's componentStats.
+// Точний шлях знає лише дашборд (iframe не бачить URL батька), тому він і підставляє
+// свій поточний маршрут. Фолбек тут — конвенція монтування міні-застосунків `/apps/:slug`,
+// бо старіші дашборди беруть шлях лише з цього повідомлення.
 if (isInsideIframe() && props.trackPageName) {
   trackVisit(
     props.trackPageName,
-    props.trackPagePath || `/${props.trackPageName}`,
+    props.trackPagePath || `/apps/${props.trackPageName}`,
   )
 }
 


### PR DESCRIPTION
Для коротких фіксованих списків поле пошуку лише шумить, а сховати його не було чим — у `SkySelectFilter` такий проп є, у `SkyCheckboxFilter` не було.

Дефолт `true`, поведінка існуючих споживачів не змінюється.