### PR TITLE
feat(SkyPagination): page navigation with a page-size selector (2.17.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import {
   SkyTableRow, SkyTableCell,
   useTableSort, useTableSelection, useColumnVisibility,
   FunctionalCalendar, SkyDateRangePicker,
-  SkyFilterDropdown,
+  SkyFilterDropdown, SkyPagination,
   // widgets
   SkyTileCard,
   // features
@@ -1244,6 +1244,42 @@ const range = reactive({ start: '', end: '' }) // { start, end } у формат
 
 ---
 
+## SkyPagination
+
+Посторінкова навігація в стилі таблиць адмінки: селектор кількості на сторінці, далі
+номери зі згортанням у «…». Нічого не завантажує — лише повідомляє, що обрали.
+
+```vue
+<SkyPagination
+  :total="total"
+  :page="page"
+  :page-size="pageSize"
+  :all-label="(n) => `Усі ${n}`"
+  @update:page="page = $event; reload()"
+  @update:page-size="pageSize = $event; page = 1; reload()"
+/>
+```
+
+#### Props
+
+| Prop | Тип | За замовчуванням | Опис |
+|------|-----|------------------|------|
+| `total` | `Number` | — | Скільки всього записів у вибірці, не на сторінці |
+| `page` | `Number` | — | Поточна сторінка, з одиниці |
+| `pageSize` | `Number` | — | Записів на сторінці |
+| `pageSizeOptions` | `Number[]` | `[5,10,25,50,100,200,500,750,1000]` | Варіанти селектора; лишаються менші за `total` |
+| `allLabel` | `(total) => String` | — | Підпис пункту «показати все»; без нього пункту немає |
+| `allLimit` | `Number` | `1000` | До якої кількості пропонувати «показати все» |
+| `siblings` | `Number` | `1` | Скільки сусідніх сторінок показувати обабіч поточної |
+| `disabled` | `Boolean` | `false` | Вимкнений стан |
+
+Events: `update:page`, `update:pageSize`. CSS-змінні — `--sky-pagination-*`.
+
+**Потрібен `total`.** Для курсорних джерел, де загальна кількість невідома, а вперед ведуть
+лише курсори, номери сторінок неможливі — там потрібна навігація «назад / далі».
+
+---
+
 ## SkyFilterDropdown
 
 Оболонка фільтра: тригер-чіп + панель. Бере на себе тільки спільне — стан відкриття,
@@ -1435,6 +1471,7 @@ src/
 │       ├── SkyTable/     # готова віртуал-скрол таблиця (Header/Row/Footer/DynamicScroller/items/*)
 │       ├── SkyTileCard/
 │       ├── SkyFilterDropdown/  # оболонка фільтра (тригер + панель) + FilterSearch
+│       ├── SkyPagination/     # посторінкова навігація зі селектором кількості
 │       ├── functional-calendar/ # форк vue-functional-calendar, перенесений зі SkyMarket 1:1
 │       ├── SkyDateRangePicker/  # DatePickerRange зі SkyMarket, store/langs → props/локальний стан
 │       └── <Component>/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -134,6 +134,7 @@ export default defineConfig({
             { text: 'SkySelectSearch', link: '/components/sky-select-search' },
             { text: 'SkyCheckbox', link: '/components/sky-checkbox' },
             { text: 'SkyTabs', link: '/components/sky-tabs' },
+            { text: 'SkyPagination', link: '/components/sky-pagination' },
           ],
         },
         {

--- a/docs/.vitepress/theme/ComponentGallery.vue
+++ b/docs/.vitepress/theme/ComponentGallery.vue
@@ -8,6 +8,7 @@ import SkySelect from '@/shared/ui/SkySelect/SkySelect.vue'
 import SkySelectSearch from '@/shared/ui/SkySelectSearch/SkySelectSearch.vue'
 import SkyCheckbox from '@/shared/ui/SkyCheckbox/SkyCheckbox.vue'
 import SkyTabs from '@/shared/ui/SkyTabs/SkyTabs.vue'
+import SkyPagination from '@/shared/ui/SkyPagination/SkyPagination.vue'
 import SkyBadge from '@/shared/ui/SkyBadge/SkyBadge.vue'
 import SkyAlert from '@/shared/ui/SkyAlert/SkyAlert.vue'
 import SkyLoader from '@/shared/ui/SkyLoader/SkyLoader.vue'
@@ -37,6 +38,7 @@ const checked = ref(true)
 const period = ref('week')
 const filter = ref([])
 const selectFilter = ref(null)
+const galleryPage = ref(3)
 const showModal = ref(false)
 const showDialog = ref(false)
 
@@ -173,6 +175,16 @@ const primitiveColumns = [
               { value: 'food', name: 'Їжа' },
             ]"
           />
+        </div>
+      </article>
+
+      <article class="vdk-card">
+        <header class="vdk-card__head">
+          <a href="/components/sky-pagination">SkyPagination</a>
+          <code>сторінки + кількість</code>
+        </header>
+        <div class="vdk-card__stage">
+          <SkyPagination :total="240" :page="galleryPage" :page-size="25" @update:page="galleryPage = $event" />
         </div>
       </article>
 

--- a/docs/.vitepress/theme/demos/SkyPaginationDemo.vue
+++ b/docs/.vitepress/theme/demos/SkyPaginationDemo.vue
@@ -1,0 +1,41 @@
+<script setup>
+import { ref } from 'vue'
+import SkyPagination from '@/shared/ui/SkyPagination/SkyPagination.vue'
+
+const page = ref(7)
+const pageSize = ref(25)
+const total = 1247
+
+const smallPage = ref(1)
+const smallSize = ref(10)
+
+function onSize(n) {
+  pageSize.value = n
+  page.value = 1 // інакше можна опинитись за межами нової кількості сторінок
+}
+</script>
+
+<template>
+  <Demo title="Багато сторінок" column>
+    <SkyPagination
+      :total="total"
+      :page="page"
+      :page-size="pageSize"
+      @update:page="page = $event"
+      @update:page-size="onSize"
+    />
+    <span class="vdk-demo-out">сторінка {{ page }} · по {{ pageSize }} · всього {{ total }}</span>
+  </Demo>
+
+  <Demo title="Мало записів + пункт «Усі»" column>
+    <SkyPagination
+      :total="42"
+      :page="smallPage"
+      :page-size="smallSize"
+      :all-label="(n) => `Усі ${n}`"
+      @update:page="smallPage = $event"
+      @update:page-size="smallSize = $event; smallPage = 1"
+    />
+    <span class="vdk-demo-out">сторінка {{ smallPage }} · по {{ smallSize }} · всього 42</span>
+  </Demo>
+</template>

--- a/docs/components/sky-pagination.md
+++ b/docs/components/sky-pagination.md
@@ -1,0 +1,73 @@
+# SkyPagination
+
+Посторінкова навігація в стилі таблиць адмінки: селектор кількості на сторінці, далі номери зі згортанням у «…».
+
+Компонент нічого не завантажує — лише повідомляє, що обрали. Дані тягне викликач.
+
+## Демо
+
+<ClientOnly>
+  <SkyPaginationDemo />
+</ClientOnly>
+
+## Приклад
+
+```vue
+<script setup>
+import { ref } from 'vue'
+import { SkyPagination } from '@skyservice-developers/vue-dev-kit'
+
+const page = ref(1)
+const pageSize = ref(25)
+const total = ref(0)
+
+function reload() { /* запит із page і pageSize */ }
+</script>
+
+<template>
+  <SkyPagination
+    :total="total"
+    :page="page"
+    :page-size="pageSize"
+    :all-label="(n) => `Усі ${n}`"
+    @update:page="page = $event; reload()"
+    @update:page-size="pageSize = $event; page = 1; reload()"
+  />
+</template>
+```
+
+**Скидай `page` на 1, коли змінився `pageSize`** — інакше поточна сторінка може опинитись за межами нової кількості. Компонент цього не робить сам: він не знає, чи ти хочеш лишитись приблизно на тому самому місці.
+
+## Props
+
+| Prop | Тип | За замовчуванням | Опис |
+|------|-----|------------------|------|
+| `total` | `Number` | — | Скільки всього записів у вибірці, не на сторінці |
+| `page` | `Number` | — | Поточна сторінка, з одиниці |
+| `pageSize` | `Number` | — | Записів на сторінці |
+| `pageSizeOptions` | `Number[]` | `[5, 10, 25, 50, 100, 200, 500, 750, 1000]` | Варіанти селектора; лишаються тільки менші за `total` |
+| `allLabel` | `(total) => String` | — | Підпис пункту «показати все». Без нього пункту немає |
+| `allLimit` | `Number` | `1000` | До якої кількості пропонувати «показати все» |
+| `siblings` | `Number` | `1` | Скільки сусідніх сторінок показувати обабіч поточної |
+| `disabled` | `Boolean` | `false` | Вимкнений стан (наприклад, поки триває запит) |
+
+## Events
+
+| Event | Payload | Коли |
+|-------|---------|------|
+| `update:page` | `Number` | Клік по номеру сторінки |
+| `update:pageSize` | `Number` | Вибір у селекторі кількості |
+
+## Коли не підійде
+
+Потрібен **`total`**. Для курсорних джерел (Shopify GraphQL і подібні), де загальна кількість невідома, а вперед ведуть тільки курсори, номери сторінок неможливі в принципі — там потрібна навігація «назад / далі».
+
+## CSS-змінні
+
+| Змінна | За замовчуванням | Опис |
+|--------|------------------|------|
+| `--sky-pagination-height` | `48px` | Висота панелі |
+| `--sky-pagination-font-size` | `12pt` | Розмір тексту |
+| `--sky-pagination-accent` | `#106090` | Колір номерів і селектора |
+| `--sky-pagination-current-border` | `#a9a9a9` | Рамка поточної сторінки |
+| `--sky-pagination-current-color` | `#000` | Колір тексту поточної сторінки |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyservice-developers/vue-dev-kit",
-      "version": "2.16.1",
+      "version": "2.17.0",
       "license": "MIT",
       "dependencies": {
         "@tanstack/vue-table": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/shared/ui/SkyPagination/SkyPagination.vue
+++ b/src/shared/ui/SkyPagination/SkyPagination.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+/**
+ * Посторінкова навігація в стилі таблиць адмінки (`.pagesBar` у Table.vue):
+ * селектор кількості на сторінці зліва, далі номери сторінок із «…».
+ *
+ * Компонент нічого не завантажує — лише повідомляє, що обрали. Список сторінок
+ * рахуємо самі з `total` і `pageSize`: в адмінці його готує бекенд (`json.links`),
+ * але наші ендпоінти віддають тільки загальну кількість.
+ */
+const props = withDefaults(
+  defineProps<{
+    /** Скільки всього записів у вибірці (не на сторінці). */
+    total: number;
+    /** Поточна сторінка, з одиниці. */
+    page: number;
+    pageSize: number;
+    /** Варіанти для селектора; лишаються тільки менші за `total`. */
+    pageSizeOptions?: number[];
+    /**
+     * Підпис пункту «показати все». Отримує кількість: `(n) => `Усі ${n}``.
+     * Порожній — пункту немає. З'являється, лише поки записів менше за `allLimit`.
+     */
+    allLabel?: (total: number) => string;
+    allLimit?: number;
+    /** Скільки сусідніх сторінок показувати обабіч поточної. */
+    siblings?: number;
+    disabled?: boolean;
+  }>(),
+  {
+    pageSizeOptions: () => [5, 10, 25, 50, 100, 200, 500, 750, 1000],
+    allLabel: undefined,
+    allLimit: 1000,
+    siblings: 1,
+    disabled: false,
+  },
+);
+
+const emit = defineEmits<{
+  'update:page': [number];
+  'update:pageSize': [number];
+}>();
+
+const pageCount = computed(() => Math.max(1, Math.ceil(props.total / Math.max(1, props.pageSize))));
+
+/**
+ * Пункти менші за `total` — показувати «100 на сторінці» для 40 записів немає сенсу.
+ * Поточний лишаємо завжди, інакше селектор показував би значення, якого немає в списку.
+ */
+const sizeOptions = computed(() => {
+  const fitting = props.pageSizeOptions.filter((n) => n < props.total || n === props.pageSize);
+  if (props.allLabel && props.total > 0 && props.total <= props.allLimit && !fitting.includes(props.total)) {
+    fitting.push(props.total);
+  }
+  return [...new Set(fitting)].sort((a, b) => a - b);
+});
+
+const sizeLabel = (n: number): string =>
+  props.allLabel && n === props.total ? props.allLabel(props.total) : String(n);
+
+/** Номери сторінок із «…»: перша, остання, поточна з сусідами. */
+const pages = computed<(number | '…')[]>(() => {
+  const last = pageCount.value;
+  const span = props.siblings;
+  if (last <= 5 + span * 2) return Array.from({ length: last }, (_, i) => i + 1);
+
+  const from = Math.max(2, props.page - span);
+  const to = Math.min(last - 1, props.page + span);
+  const out: (number | '…')[] = [1];
+  if (from > 2) out.push('…');
+  for (let p = from; p <= to; p++) out.push(p);
+  if (to < last - 1) out.push('…');
+  out.push(last);
+  return out;
+});
+
+const visible = computed(() => pageCount.value > 1 || sizeOptions.value.length > 1);
+
+function goTo(page: number): void {
+  if (props.disabled || page === props.page) return;
+  emit('update:page', page);
+}
+
+function onSize(e: Event): void {
+  emit('update:pageSize', Number((e.target as HTMLSelectElement).value));
+}
+</script>
+
+<template>
+  <div v-if="visible" class="sky-pagination">
+    <select
+      v-if="sizeOptions.length > 1"
+      class="sky-pagination__size"
+      :value="pageSize"
+      :disabled="disabled"
+      @change="onSize"
+    >
+      <option v-for="n in sizeOptions" :key="n" :value="n">{{ sizeLabel(n) }}</option>
+    </select>
+
+    <template v-for="(p, i) in pages">
+      <button
+        v-if="p !== '…'"
+        :key="`p${p}`"
+        type="button"
+        class="sky-pagination__page"
+        :class="{ 'is-current': p === page }"
+        :style="i === 0 && sizeOptions.length > 1 ? { marginLeft: '5px' } : undefined"
+        :disabled="disabled"
+        :aria-current="p === page ? 'page' : undefined"
+        @click="goTo(p)"
+      >
+        {{ p }}
+      </button>
+      <span v-else :key="`gap${i}`" class="sky-pagination__gap">…</span>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+/* Метрики зняті з `.pagesBar` в адмінці (Table.vue) і лишені як є. */
+.sky-pagination {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  max-width: 100%;
+  height: var(--sky-pagination-height, 48px);
+  overflow: auto;
+  font-size: var(--sky-pagination-font-size, 12pt);
+  line-height: 15px;
+}
+
+.sky-pagination__size {
+  border: none;
+  background: transparent;
+  font: inherit;
+  font-weight: 500;
+  color: var(--sky-pagination-accent, #106090);
+  cursor: pointer;
+}
+
+.sky-pagination__size:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.sky-pagination__page {
+  padding: 10px 10px 11px;
+  margin-right: 1px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  font: inherit;
+  font-weight: 500;
+  color: var(--sky-pagination-accent, #106090);
+  cursor: pointer;
+}
+
+.sky-pagination__page:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+/* Поточна — з рамкою; вона додає 2px, тож падінги зменшені рівно на стільки,
+   інакше кнопки стрибали б по висоті. */
+.sky-pagination__page.is-current {
+  padding: 9px 9px 10px;
+  border: 1px solid var(--sky-pagination-current-border, #a9a9a9);
+  color: var(--sky-pagination-current-color, #000);
+  cursor: default;
+}
+
+.sky-pagination__gap {
+  padding: 0 4px;
+}
+</style>

--- a/src/shared/ui/SkyPagination/index.ts
+++ b/src/shared/ui/SkyPagination/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SkyPagination.vue';

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -16,6 +16,7 @@ export { default as SkyDateRangePicker } from './SkyDateRangePicker';
 export { default as SkyFilterDropdown } from './SkyFilterDropdown';
 export { default as SkyInput } from './SkyInput';
 export { default as SkyLoader } from './SkyLoader';
+export { default as SkyPagination } from './SkyPagination';
 export { default as SkySelect } from './SkySelect';
 export { default as SkySelectSearch } from './SkySelectSearch';
 export { default as SkySearchInput } from './SkySearchInput';


### PR DESCRIPTION
Посторінкова навігація в стилі таблиць адмінки — для списків, де нескінченний скрол погано поєднується з масовим вибором.

Візуал знятий із `.pagesBar` (Table.vue): 48px заввишки, 12pt, номери #106090, поточна в рамці #a9a9a9. Падінги поточної зменшені на товщину рамки, щоб кнопки не стрибали.

**Відступ від адмінки:** там список сторінок готує бекенд (`json.links`), тут він рахується з `total` і `pageSize`.

**Обмеження:** потрібен `total`. Для курсорних джерел (Shopify GraphQL) номери неможливі в принципі — там треба «назад / далі».

Компонент керований: нічого не вантажить, стану не тримає.