### PR TITLE
fix(SkyPagination): box the page-size selector (2.17.2)

### DIFF
--- a/docs/components/sky-pagination.md
+++ b/docs/components/sky-pagination.md
@@ -79,3 +79,5 @@ function reload() { /* запит із page і pageSize */ }
 | `--sky-pagination-accent` | `#106090` | Колір номерів і селектора |
 | `--sky-pagination-current-border` | `#a9a9a9` | Рамка поточної сторінки |
 | `--sky-pagination-current-color` | `#000` | Колір тексту поточної сторінки |
+| `--sky-pagination-size-height` | `38px` | Висота селектора кількості |
+| `--sky-pagination-size-border` | `#a9a9a9` | Рамка селектора кількості |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyservice-developers/vue-dev-kit",
-      "version": "2.17.1",
+      "version": "2.17.2",
       "license": "MIT",
       "dependencies": {
         "@tanstack/vue-table": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/shared/ui/SkyPagination/SkyPagination.vue
+++ b/src/shared/ui/SkyPagination/SkyPagination.vue
@@ -144,8 +144,14 @@ function onSize(e: Event): void {
   line-height: 15px;
 }
 
+/* Рамка й висота — як у `.selectorPageLimit` в адмінці; бордер той самий #a9a9a9,
+   що й у поточної сторінки, тож обидві коробки виглядають однією парою. */
 .sky-pagination__size {
-  border: none;
+  height: var(--sky-pagination-size-height, 38px);
+  margin-left: 5px;
+  padding: 0 8px;
+  border: 1px solid var(--sky-pagination-size-border, #a9a9a9);
+  border-radius: 5px;
   background: transparent;
   font: inherit;
   font-weight: 500;


### PR DESCRIPTION
В адмінці селектор кількості — коробка 38px із рамкою `#a9a9a9` і радіусом 5px, а не голий текст. Метрики зняті з `.selectorPageLimit`.