### PR TITLE
feat(sdk): formatMoney (2.19.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import {
   SkyCheckboxFilter, SkySelectFilter,
   TableMassActions, TableColumnSettings, TableVirtualBody,
   // sdk
-  navigate, SkyserviceAPI, isInsideIframe,
+  navigate, SkyserviceAPI, isInsideIframe, formatMoney, currencyIcon,
   // sky-service-ui-components
   NotificationElement,
   notificationModule, globalStore,
@@ -1318,6 +1318,41 @@ Events: `update:page`, `update:pageSize`. CSS-змінні — `--sky-pagination
 | expose | `open()`, `close()`, `toggle()`, `isOpen` |
 
 CSS-змінні (`--sky-filter-*`) — див. [доки](https://74cfe434-a2b3-4d49-8fa7-db7343e399dc.apps.platform365.online/components/sky-filter-dropdown).
+
+---
+
+## formatMoney — сума зі значком валюти
+
+Живе в **SDK** (`@skyservice-developers/vue-dev-kit/sdk`), а не серед компонентів: там
+немає Vue, тож модуль доступний і адмінці на Vue 2.
+
+```ts
+import { formatMoney, currencyIcon } from '@skyservice-developers/vue-dev-kit/sdk'
+
+formatMoney('110',       { currency: 'UAH' })              // 110.00 ₴
+formatMoney('1250',      { currency: 'UAH' })              // 1 250.00 ₴
+formatMoney('110',       { currency: 'USD', locale: 'en' }) // $110.00
+formatMoney('110',       { currency: null })                // 110.00
+currencyIcon('KZT')                                         // ₸
+```
+
+| Опція | Типово | Опис |
+|---|---|---|
+| `currency` | `null` | ISO валюти. Без нього повертається лише число |
+| `locale` | `'uk'` | Мова інтерфейсу — вирішує, з якого боку значок |
+| `decimals` | `2` | Знаків після коми |
+
+**Де стоїть значок** — за правилами мови, не валюти: українська, польська й німецька
+ставлять його після числа, англійська й турецька перед. Позицію питаємо в `Intl`, а сам
+значок беремо зі свого списку: для більшості наших валют `Intl` віддає ISO-код замість
+символу (перевірено на всіх 55 — `₸`, `₺`, `zł`, `₫` він не знає).
+
+**Формат числа** зведений з адмінкою (`CurrencyFormatted` + `formatNumberWithSpaces`): дві
+копійки, тисячі через пробіл, крапка як десятковий роздільник. Локальні розділювачі
+свідомо не беремо — інакше та сама сума виглядала б по-різному в адмінці й у міні-аппі.
+
+Пробіли всередині — нерозривні, щоб ціна не переносилась на два рядки посеред числа.
+Нечислове значення повертається як є: краще показати сире, ніж `NaN`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyservice-developers/vue-dev-kit",
-      "version": "2.18.0",
+      "version": "2.19.0",
       "license": "MIT",
       "dependencies": {
         "@tanstack/vue-table": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -40,6 +40,10 @@ export type { WebviewType } from './webview';
 export { SkyserviceAPI } from './api';
 export type { SkyserviceAPIConfig } from './api';
 
+// Гроші — значок валюти й форматування суми (без Vue, доступно й з Vue 2)
+export { formatMoney, currencyIcon, CURRENCY_ICONS } from './money';
+export type { FormatMoneyOptions } from './money';
+
 // Types
 export type {
   Tradepoint,

--- a/src/sdk/money.ts
+++ b/src/sdk/money.ts
@@ -1,0 +1,128 @@
+/**
+ * Гроші: значок валюти й форматування суми. Живе в SDK, бо тут немає Vue —
+ * адмінка на Vue 2 не може імпортувати компоненти кіта, а цей модуль може взяти.
+ *
+ * Формат зведений із адмінкою (`CurrencyFormatted` + `formatNumberWithSpaces`
+ * у mathExtended.js): дві копійки, тисячі через пробіл, крапка як десятковий
+ * роздільник. Локальні розділювачі свідомо не беремо — інакше та сама сума
+ * виглядала б по-різному в адмінці й у міні-аппі.
+ */
+
+/** ISO → значок. Список курований під наші ринки, узятий з адмінки. */
+export const CURRENCY_ICONS: Record<string, string> = {
+  UAH: '₴',
+  USD: '$',
+  EUR: '€',
+  KZT: '₸',
+  GEL: 'ლ',
+  THB: '฿',
+  AMD: '֏',
+  BYN: 'Br',
+  AZN: '₼',
+  GHS: '₵',
+  KGS: 'с',
+  PLN: 'zł',
+  UZS: 'soʻm',
+  PHP: '₱',
+  IDR: 'Rp',
+  TJS: 'с',
+  DOP: '$',
+  NZD: '$',
+  TRY: '₺',
+  SGD: '$',
+  NGN: '₦',
+  MVR: 'Rf',
+  TMT: 'm',
+  MDL: 'L',
+  VND: '₫',
+  CRC: '₡',
+  INR: '₹',
+  CNY: '¥',
+  AED: '.د.إ',
+  LKR: '₨',
+  RON: 'L',
+  GBP: '£',
+  PKR: '₨',
+  KRW: '₩',
+  MYR: 'RM',
+  ILS: '₪',
+  ZAR: 'R',
+  UGX: 'USh',
+  KES: 'KSh',
+  TZS: 'TSh',
+  RSD: 'din',
+  MXN: '$',
+  VEF: 'BsF',
+  CUP: '$',
+  COP: '$',
+  KWD: '.د.ك',
+  CLP: '$',
+  IQD: '.د.ع',
+  AOA: 'Kz',
+  GTQ: 'Q',
+  CZK: 'Kč',
+  XAF: 'CFA',
+  CHF: 'Fr',
+  RUR: '₽',
+  SAR: 'SRls',
+}
+
+/** Невідомий код повертаємо як є — це краще за порожнечу біля ціни. */
+export function currencyIcon(iso: string | null | undefined): string {
+  if (!iso) return ''
+  return CURRENCY_ICONS[iso.toUpperCase()] ?? iso
+}
+
+/**
+ * Де стоїть значок, за правилами мови інтерфейсу. Українська, польська, німецька
+ * ставлять після числа, англійська й турецька — перед. Питаємо `Intl` лише про
+ * позицію: сам значок беремо свій, бо для більшості наших валют `Intl` віддає
+ * ISO-код замість символу.
+ */
+function iconGoesFirst(iso: string, locale: string): boolean {
+  try {
+    const parts = new Intl.NumberFormat(locale, { style: 'currency', currency: iso }).formatToParts(1)
+    const cur = parts.findIndex((p) => p.type === 'currency')
+    const num = parts.findIndex((p) => p.type === 'integer')
+    return cur !== -1 && num !== -1 && cur < num
+  } catch {
+    // невідомий ISO або локаль — ставимо після числа, як в адмінці
+    return false
+  }
+}
+
+export interface FormatMoneyOptions {
+  /** ISO валюти. Без нього повертається лише число. */
+  currency?: string | null
+  /** Мова інтерфейсу — вирішує, з якого боку значок. Типово 'uk'. */
+  locale?: string
+  /** Знаків після коми. Типово 2. */
+  decimals?: number
+}
+
+/**
+ * Форматує суму: `formatMoney('1250', { currency: 'UAH' })` → `1 250.00 ₴`.
+ * Нечислове значення повертається як є — краще показати сире, ніж `NaN`.
+ *
+ * Тисячі й значок відбиваються нерозривним пробілом, щоб ціна не переносилась
+ * на два рядки посеред числа.
+ */
+export function formatMoney(
+  value: string | number | null | undefined,
+  { currency = null, locale = 'uk', decimals = 2 }: FormatMoneyOptions = {},
+): string {
+  if (value == null || value === '') return ''
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n)) return String(value)
+
+  const NBSP = '\u00a0'
+  const [whole, frac] = Math.abs(n).toFixed(decimals).split('.')
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, NBSP)
+  const number = `${n < 0 ? '-' : ''}${grouped}${frac ? '.' + frac : ''}`
+
+  const icon = currencyIcon(currency)
+  if (!icon) return number
+  // Спереду значок клеїться впритул ($110.00), ззаду — через нерозривний пробіл
+  // (110.00 ₴). Так вимагає CLDR, і так це виглядає в обох випадках звично.
+  return iconGoesFirst(currency!, locale) ? `${icon}${number}` : `${number}${NBSP}${icon}`
+}


### PR DESCRIPTION
Спільний форматер сум для адмінки й міні-аппів.

Лежить у **SDK**, бо адмінка на Vue 2 і компоненти кіта взяти не може, а модуль без Vue — може.

```
formatMoney('1250', { currency: 'UAH' })               → 1 250.00 ₴
formatMoney('110',  { currency: 'USD', locale: 'en' }) → $110.00
```

Позицію значка дає мова інтерфейсу (uk/pl/de — після, en/tr — перед); позицію питаємо в `Intl`, символ беремо зі свого списку, бо `Intl` для більшості наших валют віддає ISO-код. Формат числа зведений з `CurrencyFormatted` адмінки.