### PR TITLE
fix(SkyPagination): make page-number height independent of typography

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/shared/ui/SkyPagination/SkyPagination.vue
+++ b/src/shared/ui/SkyPagination/SkyPagination.vue
@@ -164,7 +164,7 @@ function pick(size: number, close: () => void): void {
   height: var(--sky-pagination-height, 48px);
   overflow: auto;
   font-size: var(--sky-pagination-font-size, 12pt);
-  line-height: 15px;
+  line-height: var(--sky-pagination-line-height, 15px);
 }
 
 /* Рамка — на обгортці, а кнопка всередині світло-сіра: так само, як
@@ -215,8 +215,17 @@ function pick(size: number, close: () => void): void {
   transform: rotate(180deg);
 }
 
+/* Висота задана числом, а не сумою паддингів і рядка. В адмінці номери — це
+   `<a>`, і там 10/11px паддингів навколо 15px рядка дають 36px. Повторювати цю
+   арифметику кнопкою виявилось крихко: `font: inherit` — скорочення, і глобальний
+   `button { line-height: 1.5 !important }` у застосунку-споживачі його перебиває,
+   роздуваючи кнопку до 47px. Тепер типографіка на розмір не впливає взагалі. */
 .sky-pagination__page {
-  padding: 10px 10px 11px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--sky-pagination-page-height, 36px);
+  padding: 0 10px;
   margin-right: 1px;
   border: none;
   border-radius: 5px;
@@ -242,7 +251,10 @@ function pick(size: number, close: () => void): void {
    піксельним семплом зі скріншота адмінки, де `.pagesBar .pageButton` б'є
    `.pageButton_current` за специфічністю. Падінги не компенсуємо: там кнопка з
    рамкою теж на 2px вища, і центрування по флексу це ховає. */
+/* Рамка додає 2px, тож щоб зовні лишалось 38px як в адмінці, висоту задаємо
+   явно — box-sizing тут border-box. */
 .sky-pagination__page.is-current {
+  height: calc(var(--sky-pagination-page-height, 36px) + 2px);
   border: 1px solid var(--sky-pagination-border, #a9a9a9);
   cursor: default;
 }


### PR DESCRIPTION
Номер сторінки міг вирости до 47px замість 38: висота трималась на `15px рядка + 21px паддингів + 2px рамки`, а рядок успадковувався від бару через `font: inherit` — скорочення, яке глобальний `button { line-height: 1.5 !important }` перебиває.

Тепер висота задана числом, вміст центрується флексом.

| | чисто | з `button{line-height:1.5!important}` |
|---|---|---|
| було | 38 / 36 | **47** / 45 |
| стало | 38 / 36 | 38 / 36 |

Ширина без змін. 2.19.2