### PR TITLE
style(SkyCheckboxFilter): tighten spacing above the options list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyservice-developers/vue-dev-kit",
-  "version": "2.19.2",
+  "version": "2.19.3",
   "description": "Vue 3 component library + TypeScript SDK (iframe bridge + HTTP API) for Skyservice mini-apps",
   "type": "module",
   "main": "./dist/vue-dev-kit.cjs",

--- a/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
+++ b/src/features/SkyCheckboxFilter/SkyCheckboxFilter.vue
@@ -158,6 +158,7 @@ function clearAll(): void {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  padding-top: 3px;
   padding-left: 3px;
 }
 

--- a/src/shared/ui/SkyFilterDropdown/FilterSearch.vue
+++ b/src/shared/ui/SkyFilterDropdown/FilterSearch.vue
@@ -43,11 +43,11 @@ const emit = defineEmits<{
   position: relative;
   display: flex;
   flex-shrink: 0;
-  margin-bottom: 15px;
+  margin-bottom: 4px;
   border-bottom: 2px solid var(--sky-filter-search-border-color, #d3d3d3);
 }
 
-.sky-filter-search:has(.sky-filter-search__input:focus) {
+.sky-filter-search:focus-within {
   border-bottom-color: var(--sky-filter-accent, #106090);
   transition: border-color 200ms;
 }


### PR DESCRIPTION
Відступ пошуку від списку 15px → 4px, списку додано 3px згори.

Заразом `:has(...:focus)` → `:focus-within` — рівносильно, але працює і в Chromium 84 (WebView2), де `:has()` немає.

2.19.3